### PR TITLE
Move to authentication section instead of own section

### DIFF
--- a/settings/admin.php
+++ b/settings/admin.php
@@ -21,9 +21,10 @@
 
 namespace OCA\Guests\Settings;
 
+use OCP\Settings\ISettings;
 use OCP\Template;
 
-class Admin implements \OCP\Settings\ISettings
+class Admin implements ISettings
 {
 
 	/**
@@ -43,7 +44,7 @@ class Admin implements \OCP\Settings\ISettings
 	 * @return string
 	 */
 	public function getSectionID() {
-		return 'guests';
+		return 'authentication';
 	}
 
 	/**


### PR DESCRIPTION
I think this makes sense in the authentication section. In core we are renaming 'Authentication' to 'User Authentication'. Better than registering its whole own section.