### PR TITLE
Use user id instead of user object in mail status

### DIFF
--- a/lib/mail.php
+++ b/lib/mail.php
@@ -206,7 +206,7 @@ class Mail {
 		// mark mail as sent
 		// TODO do not set if $result contains the recipient
 		Share::setSendMailStatus(
-			$itemType, $itemSource, Share::SHARE_TYPE_USER, $recipient, true
+			$itemType, $itemSource, Share::SHARE_TYPE_USER, $recipient->getUID(), true
 		);
 
 	}


### PR DESCRIPTION
Prevents warnings in log

- [x] TEST: creating guest user still works (email, set password)
- [x] TEST: share to existing email does not show warning any more (requires and observed in https://github.com/owncloud/core/pull/27906)

@IljaN please review