### PR TITLE
Whitelist: move "," and core to backend, have enter key working

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 guests 
 =======
 
-Create a guest user by typing his name in to the sharing dialog. The guest
+Create a guest user by typing his email address in to the sharing dialog. The guest
 will receive an email invite with a link to create an account. He has only access
 to files which are shared with him.
 
 
 Furthermore, the administrator has to whitelist the applications that guests can use.
-By default ',core,settings,avatar,files,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery' are allowed.
-The initial `,` is necessary to allow access to root resources.
+By default 'settings,avatar,files,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery' are allowed.
+
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 guests 
 =======
 
-Create a guest user by typing his email address in to the sharing dialog. The guest
+Create a guest user by typing his name in to the sharing dialog. The guest
 will receive an email invite with a link to create an account. He has only access
 to files which are shared with him.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ to files which are shared with him.
 
 
 Furthermore, the administrator has to whitelist the applications that guests can use.
-By default 'settings,avatar,files,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery' are allowed.
+By default settings,avatar,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery are allowed.
 
 
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -22,6 +22,16 @@
 return [
 	'routes' => [
 		[
+			'name' => 'register#showPasswordForm',
+			'url' => '/register/{email}/{token}',
+			'verb' => 'GET',
+		],
+		[
+			'name' => 'register#register',
+			'url' => '/register',
+			'verb' => 'POST',
+		],
+		[
 			'name' => 'settings#getConfig',
 			'url' => '/config',
 			'verb' => 'GET',
@@ -30,11 +40,6 @@ return [
 			'name' => 'settings#setConfig',
 			'url' => '/config',
 			'verb' => 'PUT',
-		],
-		[
-			'name' => 'settings#getWhitelist',
-			'url' => '/whitelist',
-			'verb' => 'GET',
 		],
 		[
 			'name' => 'settings#resetWhitelist',

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -22,16 +22,6 @@
 return [
 	'routes' => [
 		[
-			'name' => 'register#showPasswordForm',
-			'url' => '/register/{email}/{token}',
-			'verb' => 'GET',
-		],
-		[
-			'name' => 'register#register',
-			'url' => '/register',
-			'verb' => 'POST',
-		],
-		[
 			'name' => 'settings#getConfig',
 			'url' => '/config',
 			'verb' => 'GET',

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -93,29 +93,6 @@ class SettingsController extends Controller {
 	}
 
 	/**
-	 * AJAX handler for getting the whitelisted apps
-	 * We do not set the whitelist to null when it is unused. This is by design.
-	 * It allows remembering the whitelist throughout changes.
-	 *
-	 * @NoAdminRequired
-	 * @return DataResponse with the current whitelist config
-	 */
-	public function getWhitelist() {
-		$useWhitelist = $this->config->getAppValue('guests', 'useWhitelist', true);
-		if ($useWhitelist === 'true' || $useWhitelist === true) {
-			$useWhitelist = true;
-		} else {
-			$useWhitelist = false;
-		}
-		$whitelist = $this->config->getAppValue('guests', 'whitelist', AppWhitelist::DEFAULT_WHITELIST);
-		$whitelist = explode(',', $whitelist);
-		return new DataResponse([
-			'useWhitelist' => $useWhitelist,
-			'whitelist' => $whitelist,
-		]);
-	}
-
-	/**
 	 * AJAX handler for resetting the whitelisted apps
 	 *
 	 * @NoAdminRequired

--- a/js/guests.js
+++ b/js/guests.js
@@ -2,6 +2,7 @@
  * ownCloud
  *
  * @author Jörn Friedrich Dreyer <jfd@owncloud.com>
+ * @author Thomas Heinisch <t.heinisch@bw-tech.de>
  * @copyright (C) 2015-2017 ownCloud, Inc.
  *
  * This code is free software: you can redistribute it and/or modify
@@ -29,11 +30,6 @@
 		var $resetWhitelist = $section.find('#guestResetWhitelist');
 		var $msg = $section.find('.msg');
 
-		var config = { conditions: ['quota'], group: 'guests',
-			useWhitelist: true, whitelist:[
-				'','core','settings','avatar','files','files_trashbin','files_sharing'
-			]};
-
 		// functions
 
 		var loadConfig = function () {
@@ -45,12 +41,14 @@
 					// update model
 					config = data;
 					// update ui
-					if(config.useWhitelist) {
+					if (config.useWhitelist) {
 						$guestUseWhitelist.prop('checked', true);
 						$guestWhitelist.show();
+						$resetWhitelist.show();
 					} else {
 						$guestUseWhitelist.prop('checked', false);
 						$guestWhitelist.hide();
+						$resetWhitelist.hide();
 					}
 					if (config.group) {
 						$guestGroup.val(config.group);
@@ -100,6 +98,20 @@
 			}
 			config.conditions = conditions;
 		};
+		
+		var saveGroup = function () {
+			config.group = $guestGroup.val();
+			saveConfig();			
+		}
+		
+		var saveWhitelist = function () {
+			var apps = $guestWhitelist.val().split(',');
+			config.whitelist = [];
+			$.each(apps, function( index, value ) {
+				config.whitelist.push(value.trim());
+			});
+			saveConfig();			
+		}
 
 		// listen to ui changes
 		$guestsByGroup.on('change', function () {
@@ -108,26 +120,41 @@
 		});
 
 		$guestGroup.on('change', function () {
-			config.group = $guestGroup.val();
-			saveConfig();
+			saveGroup();
 		});
+		
+		$guestGroup.keypress(function (e) {
+			var key = e.which;
+			if (key == 13) {
+				saveGroup();
+				return true;
+			}
+		});
+		
 		$guestUseWhitelist.on('change', function () {
 			config.useWhitelist = $guestUseWhitelist.prop('checked');
 			if(config.useWhitelist) {
 				$guestWhitelist.show();
+				$resetWhitelist.show()
 			} else {
 				$guestWhitelist.hide();
+				$resetWhitelist.hide();
 			}
 			saveConfig();
 		});
+		
 		$guestWhitelist.on('change', function () {
-			var apps = $guestWhitelist.val().split(',');
-			config.whitelist = [];
-			$.each(apps, function( index, value ) {
-				config.whitelist.push(value.trim());
-			});
-			saveConfig();
+			saveWhitelist();
 		});
+		
+		$guestWhitelist.keypress(function (e) {
+			var key = e.which;
+			if (key == 13) {
+				saveWhitelist();
+				return true;
+			}
+		});
+		
 		$resetWhitelist.on('click', function () {
 			OC.msg.startSaving($msg);
 			$.ajax({
@@ -152,7 +179,7 @@
 				});
 			});
 		});
-
+		
 	});
 
 })();

--- a/lib/appwhitelist.php
+++ b/lib/appwhitelist.php
@@ -2,6 +2,7 @@
 
 /**
  * @author Ilja Neumann <ineumann@owncloud.com>
+ * @author Thomas Heinisch <t.heinisch@bw-tech.de>
  *
  * @copyright Copyright (c) 2017, ownCloud GmbH
  * @license AGPL-3.0
@@ -30,7 +31,7 @@ use OCP\Template;
  */
 class AppWhitelist {
 
-	const DEFAULT_WHITELIST = ',core,settings,avatar,files,files_external,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications';
+	const DEFAULT_WHITELIST = 'settings,avatar,files,files_external,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications';
 
 	public static function preSetup($params) {
 		$uid = $params['user'];
@@ -46,11 +47,7 @@ class AppWhitelist {
 		if ($isGuest && $whitelistEnabled) {
 			$path = \OC::$server->getRequest()->getRawPathInfo();
 			$app = self::getRequestedApp($path);
-			$whitelist = explode(',' , $config->getAppValue(
-				'guests',
-				'whitelist',
-				self::DEFAULT_WHITELIST
-			));
+			$whitelist = self::getWhitelist();
 
 			if (!in_array($app, $whitelist)) {
 				header('HTTP/1.0 403 Forbidden');
@@ -61,6 +58,17 @@ class AppWhitelist {
 				exit;
 			}
 		}
+	}
+
+	public static function getWhitelist() {
+		$whitelist = ',core,';
+		$whitelist .=  \OC::$server->getConfig()->getAppValue(
+			'guests',
+			'whitelist',
+			self::DEFAULT_WHITELIST
+		);
+
+		return explode(',' , $whitelist);
 	}
 
 	/**

--- a/lib/appwhitelist.php
+++ b/lib/appwhitelist.php
@@ -31,7 +31,8 @@ use OCP\Template;
  */
 class AppWhitelist {
 
-	const DEFAULT_WHITELIST = 'settings,avatar,files,files_external,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications';
+	const CORE_WHITELIST = ',core,files';
+	const DEFAULT_WHITELIST = 'settings,avatar,files_external,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications';
 
 	public static function preSetup($params) {
 		$uid = $params['user'];
@@ -61,7 +62,7 @@ class AppWhitelist {
 	}
 
 	public static function getWhitelist() {
-		$whitelist = ',core,';
+		$whitelist = self::CORE_WHITELIST;
 		$whitelist .=  \OC::$server->getConfig()->getAppValue(
 			'guests',
 			'whitelist',


### PR DESCRIPTION
* comma and core are moved to the backend and not visible in the settings any more https://github.com/owncloud/guests/issues/125
* accept enter key to save group and whitelist https://github.com/owncloud/guests/issues/112
* removed getWhitelist from settingscontroller and routes as it was not in use