### PR TITLE
do not send share information after guest had registered

### DIFF
--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -190,20 +190,6 @@ class Hooks {
 					$itemSource,
 					$registerToken
 				);
-			} else {
-				// always notify guests of new files
-				$guest = $this->userManager->get($shareWith);
-
-				if (!$guest) {
-					throw new DoesNotExistException("$shareWith does not exist");
-				}
-
-				$this->mail->sendShareNotification(
-					$this->userSession->getUser(),
-					$guest,
-					$itemType,
-					$itemSource
-				);
 			}
 		} catch (DoesNotExistException $ex) {
 			$this->logger->error("'$shareWith' does not exist", ['app'=>'guests']);

--- a/lib/mail.php
+++ b/lib/mail.php
@@ -21,14 +21,11 @@
 
 namespace OCA\Guests;
 
-
-use OC\Share\MailNotifications;
 use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IURLGenerator;
-use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Mail\IMailer;
@@ -169,45 +166,6 @@ class Mail {
 				'Couldn\'t send reset email. Please contact your administrator.'
 			));
 		}
-	}
-
-	/**
-	 * @param $sender
-	 * @param $recipient
-	 * @param $itemType
-	 * @param $itemSource
-	 */
-	public function sendShareNotification(
-		$sender,
-		IUser $recipient,
-		$itemType,
-		$itemSource
-	) {
-		$recipientList[] = $recipient;
-
-
-		$mailNotification = new MailNotifications(
-			$sender,
-			\OC::$server->getL10N('lib'),
-			$this->mailer,
-			$this->logger,
-			$this->defaults,
-			\OC::$server->getURLGenerator()
-		);
-		$this->logger->debug("sending share notification for '$itemType'"
-			. " '$itemSource' to {$recipient->getUID()}'",
-			['app' => 'guests']);
-
-		$result = $mailNotification->sendInternalShareMail(
-			$recipientList, $itemSource, $itemType
-		);
-
-		// mark mail as sent
-		// TODO do not set if $result contains the recipient
-		Share::setSendMailStatus(
-			$itemType, $itemSource, Share::SHARE_TYPE_USER, $recipient->getUID(), true
-		);
-
 	}
 
 	/**


### PR DESCRIPTION
Removed email functionality in post_shared hook when guest user is already registered (as discussed in #84).

What was tested?
Do not send w/o admin settings _Allow users to send mail notification ..._:
 * Share with a new guest user -> invite email is sent
 * Share another file with this guest user -> no email is sent

Send with admin settings
 * As an Admin in the Sharing Section check _Allow users to send mail notification for shared files to other users_
 * Share with an existing guest user
 * Check _notify by email_ in the ShareTab -> email is sent