### PR TITLE
Preserve token when reshowing form after error

### DIFF
--- a/controller/registercontroller.php
+++ b/controller/registercontroller.php
@@ -222,6 +222,9 @@ class RegisterController extends Controller {
 		} catch (\Exception $e){
 			$parameters['email'] = $email;
 			$parameters['messages']['password'] = $e->getMessage();
+			$parameters['token'] = $token;
+			$parameters['postAction'] =
+			    $this->urlGenerator->linkToRouteAbsolute('guests.register.register');
 			return new TemplateResponse(
 				$this->appName, 'form.password', $parameters, 'guest'
 			);


### PR DESCRIPTION
### Steps:

1. enable password_policy app and set some policies (or any app that can validate a password or trigger an error when setting the password)
2. create guest
3. open mail link
4. type in an invalid / non-compliant password
5. type a compliant password

### Before fix
"Token is invalid" error, cannot try again to set a password without using browser back button.

### After fix
Token is preserved and more attempts can be done.

@cortho please review

cc @pmaier1 