### PR TITLE
Apply whitelist to frontend and comments URLs

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -34,7 +34,8 @@ $eventDispatcher->addListener(
 $config = \OC::$server->getConfig();
 $groupName = $config->getAppValue('guests', 'group', \OCA\Guests\GroupBackend::DEFAULT_NAME);
 
-\OC::$server->getGroupManager()->addBackend(new \OCA\Guests\GroupBackend($groupName));
+$groupBackend = new \OCA\Guests\GroupBackend($groupName);
+\OC::$server->getGroupManager()->addBackend($groupBackend);
 \OCP\Util::connectHook('OCP\Share', 'post_shared', '\OCA\Guests\Hooks', 'postShareHook');
 
 $user = \OC::$server->getUserSession()->getUser();
@@ -43,6 +44,10 @@ if ($user) {
     // if the whitelist is used
 	if ($config->getAppValue('guests', 'usewhitelist', 'true') === 'true') {
 		\OCP\Util::connectHook('OC_Filesystem', 'preSetup', '\OCA\Guests\AppWhitelist', 'preSetup');
+		// apply whitelist to navigation if guest user
+		if ($groupBackend->inGroup($user->getUID(), $groupName)) {
+			\OCP\Util::addScript('guests', 'navigation');
+		}
 	}
 
 	// hide email change field via css for learned guests

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -45,6 +45,11 @@ return [
 			'verb' => 'PUT',
 		],
 		[
+			'name' => 'settings#getWhitelist',
+			'url' => '/whitelist',
+			'verb' => 'GET',
+		],
+		[
 			'name' => 'settings#resetWhitelist',
 			'url' => '/whitelist/reset',
 			'verb' => 'POST',

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -118,6 +118,20 @@ class SettingsController extends Controller {
 	}
 
 	/**
+	 * AJAX handler for getting whitelisted apps
+	 *
+	 * @NoAdminRequired
+	 * @return array whitelisted apps
+	 */
+	public function getWhitelist() {
+		return [
+			'isGuest' => false,
+			'enabled' => $this->config->getAppValue('guests', 'usewhitelist', 'true') === 'true',
+			'apps' => \OCA\Guests\AppWhitelist::getWhitelist()
+		];
+	}
+
+	/**
 	 * AJAX handler for resetting the whitelisted apps
 	 *
 	 * @NoAdminRequired

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -1,8 +1,9 @@
 /**
- * ownCloud
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ * @author Thomas Heinisch <t.heinisch@bw-tech.de>
  *
- * @author Jörn Friedrich Dreyer <jfd@owncloud.com>
- * @copyright (C) 2015-2017 ownCloud, Inc.
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license GPL-2.0
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -14,8 +15,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License, version 3,
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
 (function() {
@@ -26,15 +27,63 @@
 
 		var updateNavigation = function () {
 			$.get(
-				OC.generateUrl('apps/guests/apps'),
+				OC.generateUrl('apps/guests/whitelist'),
 				'',
 				function (data) {
-					$('#navigation li').each(function (i, e){
-						var $e = $(e);
-						if ( $.inArray($e.data('id'), data.apps) < 0 ) {
-							$e.remove();
+					if (data.enabled) {
+						// remove items from navigation menu
+						$('#navigation li').each(function (i, e) {
+							var $e = $(e);
+							if ($.inArray($e.data('id'), data.apps) < 0) {
+								$e.remove();
+							}
+						});
+						if ($('#navigation li').length === 1) {
+							// only files is left, so remove menu at all
+							$('nav').remove();
 						}
-					});
+
+						// special treatment for apps in UI
+						// activity
+						if ($.inArray('activity', data.apps) < 0) {
+							$('li[data-tabid="activityTabView"]').remove();
+							$('#activityTabView').remove();
+							OC.Notification.origShowTemporary =  OC.Notification.showTemporary;
+							OC.Notification.showTemporary = function(msg) {
+								if (msg === t('activity', 'Error loading activities')) {
+									return;
+								}
+								// keep other messages
+								OC.Notification.origShowTemporary(msg);
+							};
+						}
+						// comments
+						if ( $.inArray('comments', data.apps) < 0) {
+							$('li[data-tabid="commentsTabView"]').remove();
+							$('#commentsTabView').remove();
+						}
+						// gallery
+						if ($.inArray('gallery', data.apps) < 0) {
+							$('#gallery-button').remove();
+						}
+						// settings
+						if ($.inArray('settings', data.apps) < 0) {
+							// remove settings and help
+							$('#expanddiv > ul > li:first-child').remove();
+							$('#expanddiv > ul > li:first-child').remove();
+						}
+						// trashbin
+						if ($.inArray('files_trashbin', data.apps) < 0) {
+							// remove would cause a css issue
+							$('li.nav-trashbin').hide();
+							$('.delete-selected').remove();
+						}
+						// versions
+						if ($.inArray('files_versions', data.apps) < 0) {
+							$('li[data-tabid="versionsTabView"]').remove();
+							$('#versionsTabView').remove();
+						}
+					}
 				},
 				'json'
 			);

--- a/lib/appwhitelist.php
+++ b/lib/appwhitelist.php
@@ -32,7 +32,7 @@ use OCP\Template;
  */
 class AppWhitelist {
 
-	const CORE_WHITELIST = ',core,files';
+	const CORE_WHITELIST = ',core,files,guests';
 	const DEFAULT_WHITELIST = 'settings,avatar,files_external,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications';
 
 	public static function preSetup($params) {
@@ -90,6 +90,8 @@ class AppWhitelist {
 			return 'avatar';
 		} else if (substr($url, 0, 10) === '/heartbeat') {
 			return 'heartbeat';
+		} else if (substr($url, 0, 13) === '/dav/comments') {
+			return 'comments';
 		}
 		return false;
 	}

--- a/lib/groupbackend.php
+++ b/lib/groupbackend.php
@@ -103,7 +103,7 @@ class GroupBackend implements GroupInterface {
 	 * Checks whether the user is member of a group or not.
 	 */
 	public function inGroup($uid, $gid) {
-		return in_array($uid, $this->guestMembers) && $gid === $this->groupName;
+		return in_array($uid, $this->getMembers()) && $gid === $this->groupName;
 
 	}
 


### PR DESCRIPTION
Inspired by https://github.com/owncloud/guests/issues/163 we bring back basic frontend app whitelistening:
* remove non-whitelisted apps from navigation menu
* cosmetic removal of items in files view (side nav, buttons, tabs)
* block /dav/comments if not whitelisted
