### PR TITLE
Detect existing email/user on frontend and backend

### DIFF
--- a/controller/userscontroller.php
+++ b/controller/userscontroller.php
@@ -117,6 +117,13 @@ class UsersController extends Controller {
 			);
 		}
 
+		$users = $this->userManager->getByEmail($email);
+		if (!empty($users)) {
+			$errorMessages['email'] = (string)$this->l10n->t(
+				'A username with that email already exists.'
+			);
+		}
+
 		if (!empty($errorMessages)) {
 			return new DataResponse(
 				[

--- a/js/guestshare.js
+++ b/js/guestshare.js
@@ -86,7 +86,7 @@ OC.Plugins.register('OC.Share.ShareDialogView', {
 		var oldHandler = obj.autocompleteHandler;
 		obj.autocompleteHandler = function(search, response) {
 
-		    return oldHandler.call(obj, search, function(result) {
+		    return oldHandler.call(obj, search, function(result, xhrResult) {
 				var searchTerm = search.term.trim();
 
 				// Add potential guests to the suggestions
@@ -101,16 +101,11 @@ OC.Plugins.register('OC.Share.ShareDialogView', {
 						result = [];
 					}
 
-					// only add guest entry suggestion if there isn't another matching user share entry already
-					var lowerSearchTerm = searchTerm.toLowerCase();
-					if (!_.find(result, function(entry) {
-						if (entry && entry.value
-							&& entry.value.shareType === OC.Share.SHARE_TYPE_USER
-							&& entry.value.shareWith.toLowerCase() === lowerSearchTerm) {
-							return true;
-						}
-						return false;
-					})) {
+					// only allow guest creation entry if there is no exact match (by user id or email, decided by the server)
+					if (xhrResult
+						&& xhrResult.ocs.meta.statuscode === 100
+						&& xhrResult.ocs.data.exact.users.length === 0
+					) {
 						result.push({
 							label: t('core', 'Add {unknown} (guest)', {unknown: searchTerm}),
 							value: {
@@ -119,9 +114,9 @@ OC.Plugins.register('OC.Share.ShareDialogView', {
 							}
 						});
 					}
-					response(result);
+					response(result, xhrResult);
 				}
-				response(result);
+				response(result, xhrResult);
 		    });
 		};
 		

--- a/tests/integration/guests_features/Guests.feature
+++ b/tests/integration/guests_features/Guests.feature
@@ -10,6 +10,17 @@ Scenario: Creating a guest user works fine
 	Then the HTTP status code should be "201"
 	And check that user "guest" is a guest
 
+Scenario: Cannot create a guest if a user with the same email address exists
+	Given as an "admin"
+	And user "existing-user" exists
+	When sending "PUT" to "/cloud/users/existing-user" with
+		| key | email |
+		| value | guest@example.com |
+	When user "admin" creates guest user "guest" with email "guest@example.com"
+	Then the HTTP status code should be "422"
+	# TODO: missing appropriate step in core / Provisioning
+	#And check that user "guest" does not exist
+
 Scenario: A guest user cannot upload files
 	Given as an "admin"
 	And user "admin" creates guest user "guest" with email "guest@example.com"


### PR DESCRIPTION
Prevent creating users using an email that already exists on the
backend.

The frontend now discards the guest creation entry if there is at least
one exact match for the search terms, which could refer to the user id
or email address (the latter being handled by the autocomplete backend)

Fixes https://github.com/owncloud/guests/issues/167

Requires https://github.com/owncloud/core/pull/29223 from core to be able to detect exact user matches. Without this core PR the app will still work, but the "Guest" entry will be visible. Clicking it will however display an error message. I think this is acceptable for people still on 10.0.3.
