### PR TITLE
Refactor guest user creation and cleanup

### DIFF
--- a/tests/acceptance/guests_features/Guests.feature
+++ b/tests/acceptance/guests_features/Guests.feature
@@ -17,7 +17,7 @@ Feature: Guests
     And user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/existing-user" with body
       | key   | email             |
       | value | guest@example.com |
-    When user "admin" creates guest user "guest" with email "guest@example.com" using the API
+    When user "admin" attempts to create guest user "guest" with email "guest@example.com" using the API
     Then the HTTP status code should be "422"
     And user "guest" should not exist
 


### PR DESCRIPTION
to match with current core acceptance test code.

The code prior to this failed complaining about:
```
  │
  ╳  user 'guest@example.com' was not created by this test run (Exception)
  │
  └─ @AfterScenario # GuestsContext::cleanupGuests()
```
because it was trying to use the core methods to cleanup users, but had not told core about them in the first place.