### PR TITLE
Remove use BasicStructure from local acceptance test context

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -8,6 +8,7 @@ default:
         - %paths.base%/../features/apiGuests
       contexts:
         - GuestsContext:
+        - FeatureContext:
             baseUrl:  http://localhost:8080
             adminUsername: admin
             adminPassword: admin


### PR DESCRIPTION
and use methods from core ``FeatureContext`` instead.

Helps standardize the way tests are done, and move away from the core trait files being used all over the place.