### PR TITLE
Fix guest email parsing

### DIFF
--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -214,6 +214,12 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 	 * @return string URL for the guest to register
 	 */
 	public function extractRegisterUrl($emailBody) {
+		// The character sequence "=\r\n" encodes soft line breaks in the plain
+		// text email. Remove these so that we get the full strings that we are
+		// searching for without them being "randomly" split by the soft line
+		// breaks.
+		// https://en.wikipedia.org/wiki/Quoted-printable
+		$emailBody = \str_replace("=\r\n", "", $emailBody);
 		$knownString
 			= 'Activate your guest account at ownCloud by setting a password: ';
 		$nextString = 'Then view it';
@@ -251,7 +257,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 		$emails = EmailHelper::getEmails($this->emailContext->getMailhogUrl());
 		$lastEmailBody = $emails->items[0]->Content->Body;
 		$fullRegisterUrl = $this->extractRegisterUrl($lastEmailBody);
-		
+
 		$exploded = \explode('/', $fullRegisterUrl);
 		$email = $exploded[7];
 		$token = $exploded[8];


### PR DESCRIPTION
``guests.feature:130`` started failing last night.

The email body coming back from mailhog has "soft line breaks" in it - "=\r\n" sequences.

The plain text email displays fine in the mailhog UI, and actually the format is a proper email thing:
https://en.wikipedia.org/wiki/Quoted-printable
https://groups.google.com/forum/#!topic/yesodweb/yyqM77CGVv8

And in recent guests CI that passed, I can see those sequences going around in mailhog:
https://drone.owncloud.com/owncloud/guests/187/22
```
Sun, 30 Sep 2018 23:37:51 +0000\r\nSubject: user0 shared =?utf-8?Q?=C2=BBtmp=C2=AB?= with you\r\nFrom: user0 via ownCloud <owncloud@foobar.com>\r\nTo: "guest@example.com" <guest@example.com>\r\nMIME-Version: 1.0\r\nContent-Type: multipart/alternative;\r\n boundary="_=_swift_v4_1538350671_3014a3290cf12c0980bc16ec06cb94a3_=_"\r\n'
2018/09/30 23:37:51 [SMTP 172.21.0.3:35612] Received 1024 bytes: '\r\n\r\n--_=_swift_v4_1538350671_3014a3290cf12c0980bc16ec06cb94a3_=_\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\nHey there,\r\n\r\njust letting you know that user0 shared tmp with you.\r\n\r\n=\r\nActivate your guest account at ownCloud by setting a password: http://local=\r\nhost:8080/index.php/apps/guests/register/guest@example.com/YKoBtCf2i3lotZLI=\r\nAXaIw\r\n\r\nThen view it: http://localhost:8080/index.php/f/2147483688\r\n\r\n=\r\nYou can login using the email address "guest@example.com".\r\n\r\nCheers!\r\n-=\r\n-\r\nownCloud - A safe home for all your data\r\nhttps://owncloud.org\r\n\r\n--_=_swift_v4_1538350671_3014a3290cf12c0980bc16ec06cb94a3_=_\r\nContent-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\n<table cellspacing=3D"0" cellpadding=3D"0" border=3D"0" width=3D"100%">\r\n<=\r\ntr><td>\r\n<table cellspacing=3D"0" cellpadding=3D"0" border=3D"0" width=3D"=\r\n600px">\r\n<tr>\r\n<td bgcolor=3D"#1d2d44" width=3D"20px">&nbsp;</td>\r\n<td b=\r\ngcolor=3D"#1d2d44">\r\n<img src=3D"http://loca'
2018/09/30 23:37:51 [SMTP 172.21.0.3:35612] Received 1024 bytes: 'lhost:8080/core/img/logo-mail.=\r\ngif" alt=3D"ownCloud"/>\r\n</td>\r\n</tr>\r\n<tr><td colspan=3D"2">&nbsp;</td>=\r\n</tr>\r\n<tr>\r\n<td width=3D"20px">&nbsp;</td>\r\n<td style=3D"font-weight:no=\r\nrmal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;=\r\n">\r\nHey there,<br><br>\r\n        =20\r\n         just letting you know that u=\r\nser0 shared <strong>tmp</strong> with you.<br><br>\r\n         Activate your=\r\n guest account at ownCloud by <a href=3D"http://localhost:8080/index.php/ap=\r\nps/guests/register/guest@example.com/YKoBtCf2i3lotZLIAXaIw">setting a passw=\r\nord</a>.<br><br>\r\n         Then <a href=3D"http://localhost:8080/index.php=\r\n/f/2147483688">view it!</a><br><br>You can login using the email address <s=\r\ntrong>"guest@example.com"</strong> .<br><br>Cheers!</td>\r\n</tr>\r\n<tr><td =\r\ncolspan=3D"2">&nbsp;</td></tr>\r\n<tr>\r\n=09<td width=3D"20px">&nbsp;</td>=\r\n\r\n=09<td style=3D"font-weight:normal; font-size:0.8em; line-height:1.2em; =\r\nfont-family:verdana,'arial',sans;">--<br>\r\n=09=09ownCloud -\r\n=09=09A sa'
2018/09/30 23:37:51 [SMTP 172.21.0.3:35612] Received 267 bytes: 'fe=\r\n home for all your data=09=09<br><a href=3D"https://owncloud.org">https://o=\r\nwncloud.org</a>\r\n=09</td>\r\n</tr>\r\n<tr>\r\n=09<td colspan=3D"2">&nbsp;</td=\r\n>\r\n</tr>\r\n</table>\r\n</td></tr>\r\n</table>\r\n\r\n\r\n--_=_swift_v4_1538350671_3014a3290cf12c0980bc16ec06cb94a3_=_--\r\n'
2018/09/30 23:37:51 [SMTP 172.21.0.3:35612] Received 5 bytes: '\r\n.\r\n'
2018/09/30 23:37:51 [SMTP 172.21.0.3:35612] [PROTO: DATA] Got EOF, storing message and switching to MAIL state
```

Last night, the email body returned from the mailhog JSON API seems to have started returning the whole plain text email, including those "soft line breaks".

I have no idea why the sudden change. Some docker mailhog update, or some library bumped somewhere, or???