### PR TITLE
Adjust acceptance test method call getLocalMailhogUrl

### DIFF
--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -255,7 +255,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 		$userName = $this->prepareUserNameAsFrontend(
 			$this->createdGuests[$guestDisplayName]
 		);
-		$emails = EmailHelper::getEmails($this->emailContext->getMailhogUrl());
+		$emails = EmailHelper::getEmails($this->emailContext->getLocalMailhogUrl());
 		$lastEmailBody = $emails->items[0]->Content->Body;
 		$fullRegisterUrl = $this->extractRegisterUrl($lastEmailBody);
 


### PR DESCRIPTION
``getMailhogUrl`` changed to ``getLocalMailhogUrl`` in core when separating the concept of mailhog URL from the point of view of the server and the test runner.