### PR TITLE
Rework drone acceptance tests like other apps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,8 +7,16 @@ branches: [master, release*, release/*]
 pipeline:
   install-server:
     image: owncloudci/core
-    pull: true
     version: ${OC_VERSION}
+    pull: true
+    db_type: ${DB_TYPE}
+    db_name: ${DB_NAME}
+    db_host: ${DB_TYPE}
+    db_username: autotest
+    db_password: owncloud
+    when:
+      matrix:
+        NEED_SERVER: true
 
   install-app:
     image: owncloudci/php:${PHP_VERSION}
@@ -25,7 +33,7 @@ pipeline:
       - php occ log:manage --level 0
     when:
       matrix:
-        TEST_SUITE: php
+        NEED_INSTALL_APP: true
 
   prepare-objectstore:
     image: owncloudci/php:${PHP_VERSION}
@@ -45,6 +53,27 @@ pipeline:
       matrix:
         TEST_OBJECTSTORAGE: true
 
+  fix-permissions:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - chown www-data /var/www/owncloud -R
+      - chmod 777 /var/www/owncloud/tests/acceptance/filesForUpload -R
+      - chmod +x /var/www/owncloud/tests/acceptance/run.sh
+    when:
+      matrix:
+        FIX_PERMISSIONS: true
+
+  owncloud-log:
+    image: owncloud/ubuntu:16.04
+    detach: true
+    pull: true
+    commands:
+      - tail -f /var/www/owncloud/data/owncloud.log
+    when:
+      matrix:
+        NEED_SERVER: true
+
   test-javascript:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -54,7 +83,7 @@ pipeline:
       matrix:
         TEST_SUITE: javascript
 
-  code-compliance-check:
+  owncloud-coding-standard:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
@@ -63,26 +92,21 @@ pipeline:
       - make test-php-style
     when:
       matrix:
-        TEST_SUITE: php
+        TEST_SUITE: owncloud-coding-standard
 
-  api-acceptance:
+  api-acceptance-tests:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-      - MAILHOG_HOST=mailhog
+      - TEST_SERVER_URL=http://owncloud
+      - PLATFORM=Linux
+      - MAILHOG_HOST=email
+      - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
-      - make test-acceptance
+      - make test-acceptance-api
     when:
       matrix:
-        TEST_SUITE: php
-
-  print-log:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - cat /var/www/owncloud/data/owncloud.log
-    when:
-      status:  [ failure ]
+        TEST_SUITE: api-acceptance
 
   notify:
     image: plugins/slack:1
@@ -94,12 +118,53 @@ pipeline:
       event: [ push, tag ]
 
 services:
-  mailhog:
+  mysql:
+    image: mysql:5.5
+    environment:
+      - MYSQL_USER=autotest
+      - MYSQL_PASSWORD=owncloud
+      - MYSQL_DATABASE=${DB_NAME}
+      - MYSQL_ROOT_PASSWORD=owncloud
+    when:
+      matrix:
+        DB_TYPE: mysql
+
+  pgsql:
+    image: postgres:9.4
+    environment:
+      - POSTGRES_USER=autotest
+      - POSTGRES_PASSWORD=owncloud
+      - POSTGRES_DB=${DB_NAME}
+    when:
+      matrix:
+        DB_TYPE: pgsql
+
+  oci:
+    image: deepdiver/docker-oracle-xe-11g
+    environment:
+      - ORACLE_USER=system
+      - ORACLE_PASSWORD=oracle
+      - ORACLE_DB=${DB_NAME}
+    when:
+      matrix:
+        DB_TYPE: oci
+
+  owncloud:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+     - APACHE_WEBROOT=/var/www/owncloud/
+    command: [ "/usr/local/bin/apachectl", "-e", "debug", "-D", "FOREGROUND" ]
+    when:
+      matrix:
+        NEED_SERVER: true
+
+  email:
     image: mailhog/mailhog
     pull: true
     when:
       matrix:
-        TEST_SUITE: php
+        USE_EMAIL: true
 
   scality:
     image: owncloudci/scality-s3server
@@ -113,46 +178,164 @@ services:
 matrix:
   include:
     # Javascript
-    - TEST_SUITE: javascript
-      OC_VERSION: daily-master-qa
-      PHP_VERSION: 7.1
-
-    - TEST_SUITE: javascript
-      OC_VERSION: daily-stable10-qa
-      PHP_VERSION: 7.1
-
-    # PHP Tests
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
-      TEST_SUITE: php
+      TEST_SUITE: javascript
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: javascript
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    # owncloud-coding-standard
+    - PHP_VERSION: 7.2
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: owncloud-coding-standard
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+
+    # API Acceptance Tests with core master
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
 
     - PHP_VERSION: 7.2
       OC_VERSION: daily-master-qa
-      TEST_SUITE: php
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
 
+    - PHP_VERSION: 7.2
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: pgsql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
+
+    - PHP_VERSION: 7.2
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: oci
+      DB_NAME: XE
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
+
+    # API Acceptance Tests with core stable10
     - PHP_VERSION: 5.6
       OC_VERSION: daily-stable10-qa
-      TEST_SUITE: php
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
 
     - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
-      TEST_SUITE: php
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-stable10-qa
-      TEST_SUITE: php
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
 
     - PHP_VERSION: 7.2
       OC_VERSION: daily-stable10-qa
-      TEST_SUITE: php
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
+
+    - PHP_VERSION: 7.2
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: pgsql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
+
+    - PHP_VERSION: 7.2
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: oci
+      DB_NAME: XE
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
 
       # Test on Objectstore
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
-      TEST_SUITE: php
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
       TEST_OBJECTSTORAGE: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-stable10-qa
-      TEST_SUITE: php
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
       TEST_OBJECTSTORAGE: true

--- a/Makefile
+++ b/Makefile
@@ -98,12 +98,12 @@ $(KARMA): $(nodejs_deps)
 
 # Command for running all tests.
 .PHONY: test
-test: test-acceptance test-php test-js
+test: test-acceptance-api test-php test-js
 
-# Command for running acceptance tests.
-.PHONY: test-acceptance
-test-acceptance:
-	cd $(tests_acceptance_directory) && pwd && chmod +x run.sh && ./run.sh -c ../../apps/guests/tests/acceptance/config/behat.yml
+.PHONY: test-acceptance-api
+test-acceptance-api:       ## Run API acceptance tests
+test-acceptance-api:
+	../../tests/acceptance/run.sh --type api
 
 .PHONY: test-php-lint
 test-php-lint:

--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -208,7 +208,9 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * Process the body of an email and get the URL for guest registration
+	 * Process the body of an email and get the URL for guest registration.
+	 * The guest registration URL looks something like:
+	 * http://owncloud/apps/guests/register/guest@example.com/bxuPw8ixQvxR5EvfAMEFG
 	 *
 	 * @param string $emailBody
 	 *
@@ -258,12 +260,19 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 		$emails = EmailHelper::getEmails($this->emailContext->getLocalMailhogUrl());
 		$lastEmailBody = $emails->items[0]->Content->Body;
 		$fullRegisterUrl = $this->extractRegisterUrl($lastEmailBody);
-		var_dump($fullRegisterUrl);
 
-		$exploded = \explode('/', $fullRegisterUrl);
-		$email = $exploded[7];
-		$token = $exploded[8];
-		$registerUrl = \implode('/', \array_splice($exploded, 0, 7));
+		$explodedFullRegisterUrl = \explode('/', $fullRegisterUrl);
+		$sizeOfExplodedFullRegisterUrl = \count($explodedFullRegisterUrl);
+
+		// The email address is the 2nd-last part of the URL
+		$email = $explodedFullRegisterUrl[$sizeOfExplodedFullRegisterUrl - 2];
+
+		// The token is the last part of the URL
+		$token = $explodedFullRegisterUrl[$sizeOfExplodedFullRegisterUrl - 1];
+		$registerUrl = \implode(
+			'/',
+			\array_splice($explodedFullRegisterUrl, 0, $sizeOfExplodedFullRegisterUrl - 2)
+		);
 		
 		$client = new Client();
 		$options['body'] = [

--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -258,6 +258,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 		$emails = EmailHelper::getEmails($this->emailContext->getLocalMailhogUrl());
 		$lastEmailBody = $emails->items[0]->Content->Body;
 		$fullRegisterUrl = $this->extractRegisterUrl($lastEmailBody);
+		var_dump($fullRegisterUrl);
 
 		$exploded = \explode('/', $fullRegisterUrl);
 		$email = $exploded[7];


### PR DESCRIPTION
1) Change drone.yml so that tests are run against a "full" ownCloud server rather than using the built-in PHP dev server. This makes the testing closer to real-life and also means that the server log output is not all mixed in the Behat test step output.

2) Have the "new standard" in drone that has an ``owncloud-log`` section which tails the log file.

3) Add drone jobs for some pgsql and Oracle, just so we cover those in case there is anything weird.

4) The guest registration URL parsing from the email was dependent too much on how the full URL starts off - running on a system with ownCloud installed somewhere below the server root, or that ends up with ``index.php`` in the URL path or... could break the parssing out of the email address and token. That is fixed in the 2nd commit.