### PR TITLE
Assert email found

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@ Furthermore guests are fully auditable with the [ownCloud Auditing application](
 	<licence>GPLv2</licence>
 	<author>ownCloud GmbH</author>
 	<dependencies>
-		<owncloud min-version="10.0.8" max-version="10.1" />
+		<owncloud min-version="10.0.8" max-version="11.0.0.0" />
 	</dependencies>
 	<category>collaboration</category>
 	<types>

--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -258,6 +258,11 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			$this->createdGuests[$guestDisplayName]
 		);
 		$emails = EmailHelper::getEmails($this->emailContext->getLocalMailhogUrl());
+		PHPUnit_Framework_Assert::assertGreaterThan(
+			0,
+			$emails->count,
+			"No guest registration email was found on the email server"
+		);
 		$lastEmailBody = $emails->items[0]->Content->Body;
 		$fullRegisterUrl = $this->extractRegisterUrl($lastEmailBody);
 


### PR DESCRIPTION
during acceptance test guest registration process, so that the problem is easier to see.

Otherwise the acceptance test error is like:
```
    And guest user "guest" has registered                                                                                                  # GuestsContext::guestUserRegisters()
      Notice: Undefined offset: 0 in /var/www/owncloud/apps/guests/tests/acceptance/features/bootstrap/GuestsContext.php line 261
```
which is not helpful.