### PR TITLE
[WIP] Remove user_autofocus expectation from paramters list

### DIFF
--- a/templates/form.password.php
+++ b/templates/form.password.php
@@ -39,8 +39,7 @@
 		<p class="groupbottom<?php if (!empty($_['invalidpassword'])) { ?> shake<?php } ?>">
 			<input type="password" name="password" id="password" value=""
 				placeholder="<?php p($l->t('Password')); ?>"
-				<?php p($_['user_autofocus'] ? '' : 'autofocus'); ?>
-				autocomplete="off" autocapitalize="off" autocorrect="off" required>
+				autocomplete="off" autocapitalize="off" autocorrect="off" required autofocus>
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
 		</p>
 		<div class="buttons">


### PR DESCRIPTION
Add user_autofocus to the parameter list to fix
the error thrown in the logs.

Signed-off-by: Sujith H <sharidasan@owncloud.com>