### PR TITLE
Set max version to 10

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@ Furthermore guests are fully auditable with the [ownCloud Auditing application](
 	<licence>GPLv2</licence>
 	<author>ownCloud GmbH</author>
 	<dependencies>
-		<owncloud min-version="10.0.8" max-version="11.0.0.0" />
+		<owncloud min-version="10.0.8" max-version="10" />
 	</dependencies>
 	<category>collaboration</category>
 	<types>


### PR DESCRIPTION
This is for a later guests app release as the current one 0.7.0 should go out before marketplace is ready for the new max-version format.