### PR TITLE
add --remote for running acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test: test-acceptance-api test-php test-js
 .PHONY: test-acceptance-api
 test-acceptance-api:       ## Run API acceptance tests
 test-acceptance-api:
-	../../tests/acceptance/run.sh --type api
+	../../tests/acceptance/run.sh --remote --type api
 
 .PHONY: test-php-lint
 test-php-lint:


### PR DESCRIPTION
Add the ``--remote`` switch when running acceptance tests. This helps in situations where the system-under-test and the test runner are on different systems, or running as different users. e.g. when a developer is running their server as ``www-data`` and the test runner is running as themselves.
