### PR TITLE
allow to use 'Given user has registered' step with password

### DIFF
--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -354,6 +354,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 	 * @When guest user :user registers
 	 * @When guest user :user registers and sets password to :password
 	 * @Given guest user :user has registered
+	 * @Given guest user :user has registered and set password to :password
 	 *
 	 * @param string $guestDisplayName
 	 * @param string $password


### PR DESCRIPTION
## Description
allow to use that Given step with a password

## Related Issue
https://github.com/owncloud/password_policy/issues/175

## Motivation and Context
more flexibility

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

