### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+## Submitting issues
+
+If you have questions about how to install or use ownCloud, please direct these to the [mailing list][mailinglist] or our [forum][forum]. We are also available on [IRC][irc].
+
+### Short version
+
+ * The [**issue template can be found here**][template]. Please always use the issue template when reporting issues.
+
+### Guidelines
+* Please search the existing issues first, it's likely that your issue was already reported or even fixed.
+  - Go to one of the repositories, click "issues" and type any word in the top search/command bar.
+  - You can also filter by appending e. g. "state:open" to the search string.
+  - More info on [search syntax within github](https://help.github.com/articles/searching-issues)
+* This repository ([guests](https://github.com/owncloud/guests/issues)) is *only* for issues within the ownCloud guests code.
+* __SECURITY__: Report any potential security bug to security@owncloud.com following our [security policy](https://owncloud.org/security/) instead of filing an issue in our bug tracker
+* Report the issue using our [template][template], it includes all the information we need to track down the issue.
+
+Help us to maximize the effort we can spend fixing issues and adding new features, by not reporting duplicate issues.
+
+[template]: https://raw.github.com/owncloud/core/master/issue_template.md
+[mailinglist]: https://mailman.owncloud.org/mailman/listinfo/owncloud
+[forum]: https://forum.owncloud.org/
+[irc]: https://webchat.freenode.net/?channels=owncloud&uio=d4
+
+### Contribute Code and translations
+Please check [core's contribution guidelines](https://github.com/owncloud/core/blob/master/CONTRIBUTING.md) for further information about contributing code and translations.

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ KARMA=$(NODE_PREFIX)/node_modules/.bin/karma
 JSDOC=$(NODE_PREFIX)/node_modules/.bin/jsdoc
 
 app_name=$(notdir $(CURDIR))
-doc_files=LICENSE README.md CHANGELOG.md
+doc_files=LICENSE README.md CHANGELOG.md CONTRIBUTING.md
 src_dirs=appinfo js l10n lib templates
 all_src=$(src_dirs) $(doc_files)
 build_dir=$(CURDIR)/build


### PR DESCRIPTION
While doing `Makefile` refactoring, I noticed that `CONTRIBUTING.md` does not exist in this repo.

1) add it to the repo
2) add it to the list of `doc_files` that go in the tarball

Do we want (2)?