### PR TITLE
Add Pdf Viewer to default whitelist

### DIFF
--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -31,7 +31,7 @@ use OCP\Template;
  */
 class AppWhitelist {
 	const CORE_WHITELIST = ',core,files,guests';
-	const DEFAULT_WHITELIST = 'settings,avatar,files_external,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications,password_policy,oauth2';
+	const DEFAULT_WHITELIST = 'settings,avatar,files_external,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications,password_policy,oauth2,files_pdfviewer,files_mediaviewer,richdocuments,onlyoffice,wopi';
 
 	public static function preSetup($params) {
 		$uid = $params['user'];


### PR DESCRIPTION
## Motivation and Context
Bad UX, Pdf Viewer not enabled by default. Users get warnings when accessing pdf files via WebUI

## How Has This Been Tested?
1.) Install ownCloud
2.) Enable Guest app, zero config
3) Enable files_pdfviewer
4) Share pdf file with new guest user
5) Activate new guest user
6) open pdf file

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

