### PR TITLE
Adjust composer files and app core min-version for 'drop PHP 5.6'

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Furthermore guests are fully auditable with the [ownCloud Auditing application](
 	<licence>GPLv2</licence>
 	<author>ownCloud GmbH</author>
 	<dependencies>
-		<owncloud min-version="10.1" max-version="10" />
+		<owncloud min-version="10.2" max-version="10" />
 	</dependencies>
 	<category>collaboration</category>
 	<types>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "owncloud/guests",
   "config": {
     "platform": {
-      "php": "5.6"
+      "php": "7.0.8"
     }
   },
   "require": {},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c5ebd0629d6f9ad03eac71c0a121e2b",
+    "content-hash": "558dce2349ea09e4b1f1391d8488ccb1",
     "packages": [],
     "packages-dev": [
         {
@@ -55,6 +55,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6"
+        "php": "7.0.8"
     }
 }

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "5.6.33"
+            "php": "7.0.8"
         }
     },
     "require": {


### PR DESCRIPTION
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`

because the app is now being tested only against core `stable10` upcoming `10.2` that has dropped PHP 5.6 support.
