### PR TITLE
Fix high DB load on inGroup() and getUsersGroups() calls

### DIFF
--- a/lib/GroupBackend.php
+++ b/lib/GroupBackend.php
@@ -131,7 +131,16 @@ class GroupBackend implements GroupInterface {
 	 * Checks whether the user is member of a group or not.
 	 */
 	public function inGroup($uid, $gid) {
-		return \in_array($uid, $this->getMembers()) && $gid === $this->groupName;
+		if ($gid !== $this->groupName) {
+			return false;
+		}
+		$isGuest = $this->config->getUserValue(
+			$uid,
+			'owncloud',
+			'isGuest',
+			'0'
+		);
+		return $isGuest === '1' ;
 	}
 
 	/**
@@ -146,7 +155,13 @@ class GroupBackend implements GroupInterface {
 	 * if the user exists at all.
 	 */
 	public function getUserGroups($uid) {
-		if (\in_array($uid, $this->getMembers())) {
+		$isGuest = $this->config->getUserValue(
+			$uid,
+			'owncloud',
+			'isGuest',
+			'0'
+		);
+		if ($isGuest === '1') {
 			return [$this->groupName];
 		}
 

--- a/tests/unit/GroupBackendTest.php
+++ b/tests/unit/GroupBackendTest.php
@@ -66,9 +66,32 @@ class GroupBackendTest extends TestCase {
 		$this->config
 			->method('getUsersForUserValue')
 			->willReturn($this->members);
+
+		$this->config
+			->method('getUserValue')
+			->willReturnCallback([$this, 'getUserValue']);
+
 		parent::setUp();
 	}
 
+	/**
+	 * Callback function to check group membership
+	 *
+	 * @param string $userId
+	 * @param string $arg2
+	 * @param string $arg3
+	 *
+	 * @return int|string
+	 */
+	public function getUserValue($userId, $arg2, $arg3) {
+		if ($arg2 !== 'owncloud' || $arg3 !== 'isGuest') {
+			return '0';
+		}
+		if (\in_array($userId, $this->members, true)) {
+			return '1';
+		}
+		return '0';
+	}
 	/**
 	 * Test if Group exists
 	 *
@@ -115,7 +138,13 @@ class GroupBackendTest extends TestCase {
 	 */
 	public function testGroupMembership() {
 		$isMember = $this->groupbackend->inGroup(
-			$this->members[0],
+			'User1',
+			GroupBackend::DEFAULT_NAME
+		);
+		self::assertTrue($isMember);
+
+		$isMember = $this->groupbackend->inGroup(
+			'User20',
 			GroupBackend::DEFAULT_NAME
 		);
 		self::assertTrue($isMember);
@@ -123,6 +152,12 @@ class GroupBackendTest extends TestCase {
 		$isMember = $this->groupbackend->inGroup(
 			self::getUniqueID(),
 			GroupBackend::DEFAULT_NAME
+		);
+		self::assertFalse($isMember);
+
+		$isMember = $this->groupbackend->inGroup(
+			'User21',
+			'someothergroup'
 		);
 		self::assertFalse($isMember);
 	}


### PR DESCRIPTION


## Description
Don't call getUsersForUserValue in AllConfig if not necessary. All methods with a given user context should call getUserValue.

## Related Issue
Closes https://github.com/owncloud/enterprise/issues/3242

## Motivation and Context
The current GroupInterface is not performant

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

