### PR TITLE
Adjust expected sharing dialog box text

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIGuestsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGuestsContext.php
@@ -67,7 +67,7 @@ class WebUIGuestsContext extends RawMinkContext implements Context {
 	 *
 	 * @var string
 	 */
-	private $userAddDialogBoxFramework = "Add %s (guest)";
+	private $userAddDialogBoxFramework = "Add %s (guest) Guest";
 
 	/**
 	 *

--- a/tests/acceptance/features/webUIGuests/guests.feature
+++ b/tests/acceptance/features/webUIGuests/guests.feature
@@ -35,7 +35,7 @@ Feature: Guests
     Then user "valid@email.com" should exist
 
   @mailhog
-  Scenario: User uses some random string email to crete a guest user
+  Scenario: User uses some random string email to create a guest user
     Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has logged in using the webUI
     And the user has opened the share dialog for folder "lorem.txt"


### PR DESCRIPTION
## Description
core PR https://github.com/owncloud/core/pull/35397 changed the display of the various types of users in the webUI sharing dropdown list.

Adjust the test expectation here in the guests app.

## Related Issue
https://github.com/owncloud/core/issues/35098

## Motivation and Context
`guests` app acceptance tests started failing.
Make them great again.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

