### PR TITLE
Adjust guest sharing dropdown text

### DIFF
--- a/js/guestshare.js
+++ b/js/guestshare.js
@@ -140,7 +140,7 @@
 
 							if (provideGuestEntry) {
 								result.push({
-									label: t('core', 'Add {unknown} (guest)', {unknown: searchTerm}),
+									label: t('core', 'Add {unknown}', {unknown: searchTerm}),
 									value: {
 										shareType: OC.Share.SHARE_TYPE_GUEST,
 										shareWith: searchTerm

--- a/tests/acceptance/features/bootstrap/WebUIGuestsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGuestsContext.php
@@ -67,7 +67,7 @@ class WebUIGuestsContext extends RawMinkContext implements Context {
 	 *
 	 * @var string
 	 */
-	private $userAddDialogBoxFramework = "Add %s (guest) Guest";
+	private $userAddDialogBoxFramework = "Add %s Guest";
 
 	/**
 	 *


### PR DESCRIPTION
## Description
The recent enhancement of the webUI sharing dropdown list in core PR https://github.com/owncloud/core/pull/35397 now puts the user type (local, federated, guest etc) on a second line. The extra `(guest)` in brackets that the guest app is putting is no longer needed and just adds redundant data to the user experience.

Remove the `(guest)` in brackets from the sharing dropdown list.

## Related Issue
https://github.com/owncloud/core/issues/35098

## Motivation and Context
Make the guests sharing webUI behavior match the recent changes in the core PR https://github.com/owncloud/core/pull/35397

## How Has This Been Tested?
Observing local webUI test runs to see that the share dropdown no longer has the extra `(guest)` text.

## Screenshots (if appropriate):

![sharing-dropdown-out-11](https://user-images.githubusercontent.com/1535615/59575807-ae1f4300-90dc-11e9-8f98-16cef44f39ea.jpg)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

