### PR TITLE
guest app test against 10.2.1 tarball

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -582,7 +582,7 @@ matrix:
 
       # Release Tarball
     - PHP_VERSION: 7.1
-      OC_VERSION: 10.2.0
+      OC_VERSION: 10.2.1
       TEST_SUITE: api-acceptance
       BEHAT_SUITE: apiGuests
       DB_TYPE: mysql
@@ -595,7 +595,7 @@ matrix:
       FIX_PERMISSIONS: true
 
     - PHP_VERSION: 7.1
-      OC_VERSION: 10.2.0
+      OC_VERSION: 10.2.1
       TEST_SUITE: webui-acceptance
       BEHAT_SUITE: webUIGuests
       DB_TYPE: mysql


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This test guarantee that the ```guests``` app runs correctly against 10.2.1 tarball.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Core 10.2.1 is officially released, we we need guests app to run correctly against this latest release.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

