### PR TITLE
bump-min-version-release-0.8.2

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Furthermore guests are fully auditable with the [ownCloud Auditing application](
 	<licence>GPLv2</licence>
 	<author>ownCloud GmbH</author>
 	<dependencies>
-		<owncloud min-version="10.2" max-version="10" />
+		<owncloud min-version="10.3" max-version="10" />
 	</dependencies>
 	<category>collaboration</category>
 	<types>


### PR DESCRIPTION
Bump oC min-version to 10.3 for guest release-0.8.2 in order to adjust with core changes