### PR TITLE
Remove scality obectstore drone tests for now

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -425,20 +425,6 @@ matrix:
       USE_EMAIL: true
       NEED_USER_MANAGEMENT_APP: true
 
-      # Test on Objectstore
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiGuests
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      FIX_PERMISSIONS: true
-      USE_EMAIL: true
-      TEST_OBJECTSTORAGE: true
-
       # Release Tarball
     - PHP_VERSION: 7.1
       OC_VERSION: 10.2.1


### PR DESCRIPTION
This is the same problem as https://github.com/owncloud/core/issues/36002
Remove the scality test matrix for now.
(and put it back when the core issue is resolved)