### PR TITLE
Revert "Remove scality obectstore drone tests for now"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -425,6 +425,20 @@ matrix:
       USE_EMAIL: true
       NEED_USER_MANAGEMENT_APP: true
 
+      # Test on Objectstore
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiGuests
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      FIX_PERMISSIONS: true
+      USE_EMAIL: true
+      TEST_OBJECTSTORAGE: true
+
       # Release Tarball
     - PHP_VERSION: 7.1
       OC_VERSION: 10.2.1


### PR DESCRIPTION
This reverts commit 1a03930fa282404111321d8919cb7d12492cc43c.

from PR #352 because scality S3 server is working now.

Issue https://github.com/owncloud/core/issues/36002