### PR TITLE
Use rawurldecode for allowing "+" in guests emails

### DIFF
--- a/lib/Controller/UsersController.php
+++ b/lib/Controller/UsersController.php
@@ -114,7 +114,7 @@ class UsersController extends Controller {
 	 */
 	public function create($email, $displayName) {
 		$errorMessages = [];
-		$email = \trim(\urldecode($email));
+		$email = \trim(\rawurldecode($email));
 		$username = \strtolower($email);
 
 		if (empty($email) || !$this->mailer->validateMailAddress($email)) {

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -5,10 +5,16 @@ Feature: Guests
     Given using OCS API version "1"
     And using new dav path
 
-  Scenario: Creating a guest user works fine
-    When the administrator creates guest user "guest" with email "guest@example.com" using the API
+  Scenario Outline: Creating a guest user works fine
+    When the administrator creates guest user "<user>" with email "<email-address>" using the API
     Then the HTTP status code should be "201"
-    And user "guest" should be a guest user
+    And user "<user>" should be a guest user
+    And the email address of user "<email-address>" should be "<email-address>"
+    Examples:
+      | email-address                  | user                 |
+      | guest@example.com              | guest                |
+      | john.smith@email.com           | john.smith           |
+      | betty_anne+bob-burns@email.com | betty_anne+bob-burns |
 
   Scenario: Cannot create a guest if a user with the same email address exists
     Given user "existing-user" has been created with default attributes and skeleton files
@@ -37,15 +43,21 @@ Feature: Guests
     And as "user0" file "/textfile.txt" should not exist
 
   @mailhog
-  Scenario: A guest user can upload files to a folder shared with them
+  Scenario Outline: A guest user can upload files to a folder shared with them
     Given user "user0" has been created with default attributes and skeleton files
-    And the administrator has created guest user "guest" with email "guest@example.com"
+    And the administrator has created guest user "<user>" with email "<email-address>"
     And the HTTP status code should be "201"
     And user "user0" has created folder "/tmp"
-    And user "user0" has shared folder "/tmp" with user "guest@example.com"
-    And guest user "guest" has registered
-    When user "guest@example.com" uploads file "textfile.txt" from the guests test data folder to "/tmp/textfile.txt" using the WebDAV API
+    And user "user0" has shared folder "/tmp" with user "<email-address>"
+    And guest user "<user>" has registered
+    When user "<email-address>" uploads file "textfile.txt" from the guests test data folder to "/tmp/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
+    And as "user0" file "/tmp/textfile.txt" should exist
+    Examples:
+      | email-address                  | user                 |
+      | guest@example.com              | guest                |
+      | john.smith@email.com           | john.smith           |
+      | betty_anne+bob-burns@email.com | betty_anne+bob-burns |
 
   @mailhog
   Scenario: A guest user can upload chunked files to a folder shared with them

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -5,6 +5,7 @@ Feature: Guests
     Given using OCS API version "1"
     And using new dav path
 
+  @skipOnOcV10.3
   Scenario Outline: Creating a guest user works fine
     When the administrator creates guest user "<user>" with email "<email-address>" using the API
     Then the HTTP status code should be "201"
@@ -42,7 +43,7 @@ Feature: Guests
     And as "guest@example.com" file "/textfile.txt" should not exist
     And as "user0" file "/textfile.txt" should not exist
 
-  @mailhog
+  @mailhog @skipOnOcV10.3
   Scenario Outline: A guest user can upload files to a folder shared with them
     Given user "user0" has been created with default attributes and skeleton files
     And the administrator has created guest user "<user>" with email "<email-address>"

--- a/tests/acceptance/features/webUIGuests/guests.feature
+++ b/tests/acceptance/features/webUIGuests/guests.feature
@@ -28,11 +28,16 @@ Feature: Guests
     And a warning should be displayed on the set-password-page saying "The token is invalid"
 
   @mailhog @skipOnOcV10.2
-  Scenario: User uses valid email to create a guest user
+  Scenario Outline: User uses valid email to create a guest user
     Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has logged in using the webUI
-    When the user shares file "data.zip" with guest user with email "valid@email.com" using the webUI
-    Then user "valid@email.com" should exist
+    When the user shares file "data.zip" with guest user with email "<email-address>" using the webUI
+    Then user "<email-address>" should exist
+    Examples:
+      | email-address                  |
+      | valid@email.com                |
+      | John.Smith@email.com           |
+      | Betty_Anne+Bob-Burns@email.com |
 
   @mailhog
   Scenario: User uses some random string email to create a guest user
@@ -140,16 +145,22 @@ Feature: Guests
     Then the user should not have permission to upload or create files
 
   @mailhog
-  Scenario: Guest user is able to upload or create files inside the received share(with change permission)
+  Scenario Outline: Guest user is able to upload or create files inside the received share(with change permission)
     Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has logged in using the webUI
-    When the user shares folder "simple-folder" with guest user with email "guest@example.com" using the webUI
+    When the user shares folder "simple-folder" with guest user with email "<email-address>" using the webUI
     And the user logs out of the webUI
-    And guest user "guest@example.com" registers with email "guest@example.com" and sets password to "password" using the webUI
-    And user "guest@example.com" logs in using the webUI
+    And guest user "<email-address>" registers with email "<email-address>" and sets password to "password" using the webUI
+    And user "<email-address>" logs in using the webUI
     And the user opens folder "simple-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
+    And as "user0" file "/simple-folder/new-lorem.txt" should exist
+    Examples:
+      | email-address                  |
+      | guest@example.com              |
+      | John.Smith@email.com           |
+      | Betty_Anne+Bob-Burns@email.com |
 
   @mailhog
   Scenario: Guest user tries to upload or create files inside the received share(read only permission)

--- a/tests/acceptance/features/webUIGuests/guests.feature
+++ b/tests/acceptance/features/webUIGuests/guests.feature
@@ -27,7 +27,7 @@ Feature: Guests
     Then the user should be redirected to a webUI page with the title "%productname%"
     And a warning should be displayed on the set-password-page saying "The token is invalid"
 
-  @mailhog @skipOnOcV10.2
+  @mailhog @skipOnOcV10.2 @skipOnOcV10.3
   Scenario Outline: User uses valid email to create a guest user
     Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has logged in using the webUI
@@ -144,7 +144,7 @@ Feature: Guests
     And user "guest@example.com" logs in using the webUI
     Then the user should not have permission to upload or create files
 
-  @mailhog
+  @mailhog @skipOnOcV10.3
   Scenario Outline: Guest user is able to upload or create files inside the received share(with change permission)
     Given user "user0" has been created with default attributes and skeleton files
     And user "user0" has logged in using the webUI

--- a/tests/acceptance/features/webUIGuests/guests.feature
+++ b/tests/acceptance/features/webUIGuests/guests.feature
@@ -83,15 +83,15 @@ Feature: Guests
     And user "valid@email.com" should exist
     # And user "valid@email.com" should not exist
 
-  @mailhog @issue-332 @skipOnOcV10.2 @skipOnFIREFOX
+  @mailhog @skipOnOcV10.2 @skipOnFIREFOX
   Scenario: Administrator changes the guest user's password in users menu
     Given user "admin" has uploaded file with content "new content" to "new-file.txt"
     And the administrator has logged in using the webUI
     And the user shares file "new-file.txt" with guest user with email "valid@email.com" using the webUI
     And the administrator has browsed to the users page
     When the administrator changes the password of user "valid@email.com" to "newpassword" using the webUI
-    #Then notifications should be displayed on the webUI with the text
-    #  | Password successfully changed |
+    Then notifications should be displayed on the webUI with the text
+      | Password successfully changed |
     When the administrator logs out of the webUI
     And the user logs in with username "valid@email.com" and password "newpassword" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"


### PR DESCRIPTION
## Description

Use `rawurldecode` instead of `urldecode` for allowing `+` in guests emails since `urldecode` decodes also `+` symbol to a space character.

## Related Issue

- Requires https://github.com/owncloud/core/pull/36613
- Fixes https://github.com/owncloud/enterprise/issues/3712

- also fixes #332 (the test steps about changing password of a guest user work fine now, so they are enabled again, see the last commit)

## Motivation and Context

Since `urldecode` decodes also `+` symbol to a space character it is not possible to create guest users having i.e. the following format `name+2@test.com`, which is a perfectly fine format.

## How Has This Been Tested?

Manually by sharing with guest users having the `name+2@test.com` format over the sharing dialogue.

Acceptance tests scenarios have been added - see 2nd commit.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.