### PR TITLE
Acceptance test to assert regular user can be created using same email as of guest user

### DIFF
--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -220,3 +220,11 @@ Feature: Guests
     And guest user "guest" registers
     When user "guest@example.com" has created guest user "guest2" with email "guest2@example.com"
     Then the HTTP status code should be "403"
+
+  @mailhog
+  Scenario: Create a regular user using the same email address of an existing guest user
+    Given the administrator has created guest user "guest" with email "guest@example.com"
+    When the administrator creates these users with skeleton files:
+      | username    | email             |
+      | regularUser | guest@example.com |
+    Then the email address of user "regularUser" should be "guest@example.com"

--- a/tests/acceptance/features/webUIGuests/guests.feature
+++ b/tests/acceptance/features/webUIGuests/guests.feature
@@ -151,14 +151,25 @@ Feature: Guests
       And the user uploads file "new-lorem.txt" using the webUI
       Then file "new-lorem.txt" should be listed on the webUI
 
-    @mailhog
-    Scenario: Guest user tries to upload or create files inside the received share(read only permission)
-      Given user "user0" has been created with default attributes and skeleton files
-      And the administrator has created guest user "guest" with email "guest@example.com"
-      And user "user0" has shared folder "simple-folder" with user "guest@example.com"
-      When user "user0" updates the last share using the sharing API with
-        | permissions | read |
-      And guest user "guest" registers and sets password to "password" using the webUI
-      And user "guest@example.com" logs in using the webUI
-      And the user opens folder "simple-folder" using the webUI
-      Then the user should not have permission to upload or create files
+  @mailhog
+  Scenario: Guest user tries to upload or create files inside the received share(read only permission)
+    Given user "user0" has been created with default attributes and skeleton files
+    And the administrator has created guest user "guest" with email "guest@example.com"
+    And user "user0" has shared folder "simple-folder" with user "guest@example.com"
+    When user "user0" updates the last share using the sharing API with
+      | permissions | read |
+    And guest user "guest" registers and sets password to "password" using the webUI
+    And user "guest@example.com" logs in using the webUI
+    And the user opens folder "simple-folder" using the webUI
+    Then the user should not have permission to upload or create files
+
+  @mailhog
+  Scenario: Create a regular user using the same email address of an existing guest user
+    Given the administrator has created guest user "guest" with email "guest@example.com"
+    And the administrator has logged in using the webUI
+    And the administrator has browsed to the users page
+    When the administrator creates a user with the name "regularUser" and the email "guest@example.com" without a password using the webUI
+    Then the administrator should be able to see the email of these users in the User Management page:
+      | username    | email             |
+      | regularUser | guest@example.com |
+    And the email address of user "regularUser" should be "guest@example.com"


### PR DESCRIPTION


<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Guests app. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
Add acceptance test to assert that regular user can be created using same email as of guest user

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

