### PR TITLE
[Tests-Only] API acceptance tests for guest users with uppercases in email

### DIFF
--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -14,7 +14,7 @@ Feature: Guests
     Examples:
       | email-address                  | user                 |
       | guest@example.com              | guest                |
-      | john.smith@email.com           | John.Smith           |
+      | John.Smith@email.com           | John.Smith           |
       | betty_anne+bob-burns@email.com | betty_anne+bob-burns |
 
   Scenario: Cannot create a guest if a user with the same email address exists
@@ -49,7 +49,7 @@ Feature: Guests
     And the administrator has created guest user "<user>" with email "<email-address>"
     And the HTTP status code should be "201"
     And user "user0" has created folder "/tmp"
-    And user "user0" has shared folder "/tmp" with user "<email-address>"
+    And user "user0" has shared folder "/tmp" with guest user "<email-address>"
     And guest user "<user>" has registered
     When user "<email-address>" uploads file "textfile.txt" from the guests test data folder to "/tmp/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -57,7 +57,7 @@ Feature: Guests
     Examples:
       | email-address                  | user                 |
       | guest@example.com              | guest                |
-      | john.smith@email.com           | John.Smith           |
+      | John.Smith@email.com           | John.Smith           |
       | betty_anne+bob-burns@email.com | betty_anne+bob-burns |
 
   @mailhog

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -16,6 +16,7 @@ Feature: Guests
       | guest@example.com              | guest                |
       | john.smith@email.com           | john.smith           |
       | betty_anne+bob-burns@email.com | betty_anne+bob-burns |
+      | John.Smith@email.com           | John.Smith           |
 
   Scenario: Cannot create a guest if a user with the same email address exists
     Given user "existing-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -14,9 +14,8 @@ Feature: Guests
     Examples:
       | email-address                  | user                 |
       | guest@example.com              | guest                |
-      | john.smith@email.com           | john.smith           |
+      | john.smith@email.com           | John.Smith           |
       | betty_anne+bob-burns@email.com | betty_anne+bob-burns |
-      | John.Smith@email.com           | John.Smith           |
 
   Scenario: Cannot create a guest if a user with the same email address exists
     Given user "existing-user" has been created with default attributes and skeleton files
@@ -58,7 +57,7 @@ Feature: Guests
     Examples:
       | email-address                  | user                 |
       | guest@example.com              | guest                |
-      | john.smith@email.com           | john.smith           |
+      | john.smith@email.com           | John.Smith           |
       | betty_anne+bob-burns@email.com | betty_anne+bob-burns |
 
   @mailhog

--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -569,7 +569,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 	 * @throws Exception
 	 */
 	public function userHasSharedFolderWithGuestUser($sharer, $filePath, $guestUser, $permissions = null) {
-		$guestUser = $this->prepareUserNameAsFrontend($guestUser);
+		$guestUser = \urldecode($this->prepareUserNameAsFrontend($guestUser));
 		$this->featureContext->shareFileWithUserUsingTheSharingApi(
 			$sharer, $filePath, $guestUser, $permissions, true
 		);

--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -126,8 +126,8 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 	 *
 	 * @return string
 	 */
-	public function prepareUserNameAsFrontend($guestEmail) {
-		return \str_replace('+', '%2B', \strtolower(\trim($guestEmail)));
+	public function prepareUserName($guestEmail) {
+		return \str_replace('+', '%2B', \trim($guestEmail));
 	}
 
 	/**
@@ -229,7 +229,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			$user, $source, $destination, $noOfChunks, $chunkingVersion, $async
 		);
 	}
-	
+
 	/**
 	 * @When /^user "([^"]*)" uploads file "([^"]*)" from the guests test data folder asynchronously to "([^"]*)" in (\d+) chunks using the WebDAV API$/
 	 *
@@ -247,7 +247,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			$user, $source, $destination, $noOfChunks, "new", true
 		);
 	}
-	
+
 	/**
 	 * @param string $user
 	 * @param string $guestDisplayName
@@ -262,8 +262,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 		$user = $this->featureContext->getActualUsername($user);
 		$fullUrl
 			= $this->featureContext->getBaseUrl() . '/index.php/apps/guests/users';
-		//Replicating frontend behaviour
-		$userName = $this->prepareUserNameAsFrontend($guestEmail);
+		$userName = $this->prepareUserName($guestEmail);
 		$fullUrl
 			= $fullUrl
 			. "?displayName=$guestDisplayName&email=$userName&username=$userName";
@@ -388,7 +387,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			$this->createdGuests,
 			__METHOD__ . " guest user '$guestDisplayName' has not been successfully created by this scenario"
 		);
-		$userName = $this->prepareUserNameAsFrontend(
+		$userName = $this->prepareUserName(
 			$this->createdGuests[$guestDisplayName]
 		);
 		$this->featureContext->userShouldBelongToGroup($userName, 'guest_app');
@@ -403,7 +402,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 	 * @throws Exception
 	 */
 	public function deleteGuestUser($guestDisplayName) {
-		$userName = $this->prepareUserNameAsFrontend(
+		$userName = $this->prepareUserName(
 			$this->createdGuests[$guestDisplayName]
 		);
 		$this->featureContext->deleteUser($userName);
@@ -497,7 +496,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			'token' => $token,
 			'password' => $password
 		];
-		
+
 		$response = HttpRequestHelper::sendRequest(
 			$registerUrl,
 			'POST',

--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -126,8 +126,8 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 	 *
 	 * @return string
 	 */
-	public function prepareUserName($guestEmail) {
-		return \str_replace('+', '%2B', \trim($guestEmail));
+	public function prepareUserNameAsFrontend($guestEmail) {
+		return \str_replace('+', '%2B', \strtolower(\trim($guestEmail)));
 	}
 
 	/**
@@ -229,7 +229,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			$user, $source, $destination, $noOfChunks, $chunkingVersion, $async
 		);
 	}
-
+	
 	/**
 	 * @When /^user "([^"]*)" uploads file "([^"]*)" from the guests test data folder asynchronously to "([^"]*)" in (\d+) chunks using the WebDAV API$/
 	 *
@@ -247,7 +247,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			$user, $source, $destination, $noOfChunks, "new", true
 		);
 	}
-
+	
 	/**
 	 * @param string $user
 	 * @param string $guestDisplayName
@@ -262,7 +262,8 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 		$user = $this->featureContext->getActualUsername($user);
 		$fullUrl
 			= $this->featureContext->getBaseUrl() . '/index.php/apps/guests/users';
-		$userName = $this->prepareUserName($guestEmail);
+		//Replicating frontend behaviour
+		$userName = $this->prepareUserNameAsFrontend($guestEmail);
 		$fullUrl
 			= $fullUrl
 			. "?displayName=$guestDisplayName&email=$userName&username=$userName";
@@ -387,7 +388,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			$this->createdGuests,
 			__METHOD__ . " guest user '$guestDisplayName' has not been successfully created by this scenario"
 		);
-		$userName = $this->prepareUserName(
+		$userName = $this->prepareUserNameAsFrontend(
 			$this->createdGuests[$guestDisplayName]
 		);
 		$this->featureContext->userShouldBelongToGroup($userName, 'guest_app');
@@ -402,7 +403,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 	 * @throws Exception
 	 */
 	public function deleteGuestUser($guestDisplayName) {
-		$userName = $this->prepareUserName(
+		$userName = $this->prepareUserNameAsFrontend(
 			$this->createdGuests[$guestDisplayName]
 		);
 		$this->featureContext->deleteUser($userName);
@@ -496,7 +497,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			'token' => $token,
 			'password' => $password
 		];
-
+		
 		$response = HttpRequestHelper::sendRequest(
 			$registerUrl,
 			'POST',

--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -229,7 +229,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			$user, $source, $destination, $noOfChunks, $chunkingVersion, $async
 		);
 	}
-	
+
 	/**
 	 * @When /^user "([^"]*)" uploads file "([^"]*)" from the guests test data folder asynchronously to "([^"]*)" in (\d+) chunks using the WebDAV API$/
 	 *
@@ -247,7 +247,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			$user, $source, $destination, $noOfChunks, "new", true
 		);
 	}
-	
+
 	/**
 	 * @param string $user
 	 * @param string $guestDisplayName
@@ -264,10 +264,11 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			= $this->featureContext->getBaseUrl() . '/index.php/apps/guests/users';
 		//Replicating frontend behaviour
 		$userName = $this->prepareUserNameAsFrontend($guestEmail);
-		$fullUrl
-			= $fullUrl
-			. "?displayName=$guestDisplayName&email=$userName&username=$userName";
-
+		$body = [
+			'displayName' => $guestDisplayName,
+			'userName' => $userName,
+			'email' => $guestEmail
+		];
 		$headers = [];
 		$headers['Content-Type'] = 'application/x-www-form-urlencoded';
 		$response = HttpRequestHelper::sendRequest(
@@ -275,7 +276,8 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			'PUT',
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$headers
+			$headers,
+			$body
 		);
 
 		$this->featureContext->setResponse($response);
@@ -475,7 +477,6 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 
 		// The email address is the 2nd-last part of the URL
 		$email = $explodedFullRegisterUrl[$sizeOfExplodedFullRegisterUrl - 2];
-
 		// The token is the last part of the URL
 		$token = $explodedFullRegisterUrl[$sizeOfExplodedFullRegisterUrl - 1];
 		$registerUrl = \implode(
@@ -497,7 +498,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			'token' => $token,
 			'password' => $password
 		];
-		
+
 		$response = HttpRequestHelper::sendRequest(
 			$registerUrl,
 			'POST',
@@ -554,5 +555,28 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
 		$this->emailContext = $environment->getContext('EmailContext');
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with guest user "([^"]*)"(?: with permissions (\d+))?$/
+	 *
+	 * @param string $sharer
+	 * @param string $filePath
+	 * @param string $guestUser
+	 * @param string|null $permissions
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userHasSharedFolderWithGuestUser($sharer, $filePath, $guestUser, $permissions = null) {
+		$guestUser = $this->prepareUserNameAsFrontend($guestUser);
+		$this->featureContext->shareFileWithUserUsingTheSharingApi(
+			$sharer, $filePath, $guestUser, $permissions, true
+		);
+		// this is expected to fail if a file is shared with create and delete permissions, which is not possible
+		Assert::assertTrue(
+			$this->featureContext->isUserOrGroupInSharedData($guestUser, "user", $permissions),
+			"User $sharer failed to share $filePath with user $guestUser"
+		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/WebUIGuestsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGuestsContext.php
@@ -119,7 +119,7 @@ class WebUIGuestsContext extends RawMinkContext implements Context {
 	 * @throws Exception
 	 */
 	public function guestUserRegistersUsingWebUI($guestDisplayName, $password) {
-		$userName = $this->guestsContext->prepareUserName(
+		$userName = $this->guestsContext->prepareUserNameAsFrontend(
 			$this->guestsContext->getCreatedGuests()[$guestDisplayName]
 		);
 

--- a/tests/acceptance/features/bootstrap/WebUIGuestsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGuestsContext.php
@@ -119,7 +119,7 @@ class WebUIGuestsContext extends RawMinkContext implements Context {
 	 * @throws Exception
 	 */
 	public function guestUserRegistersUsingWebUI($guestDisplayName, $password) {
-		$userName = $this->guestsContext->prepareUserNameAsFrontend(
+		$userName = $this->guestsContext->prepareUserName(
 			$this->guestsContext->getCreatedGuests()[$guestDisplayName]
 		);
 


### PR DESCRIPTION
## Description
`username` of a `guest user` is set to `lower-cased email addr` during creation. So, `lower-cased` email should be used to share resource with guest user.

## Related Issue
- fixes https://github.com/owncloud/guests/issues/395

## Motivation and Context
share with guest users with emails containing upper-case letters

## How Has This Been Tested?
- :rabbit: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

