### PR TITLE
[0.8.3] Pin behat/mink to 1.7.1 and update other acceptance test dependencies

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,19 +1,20 @@
 {
     "config" : {
         "platform": {
-            "php": "7.1"
+            "php": "7.1.3"
         }
     },
     "require": {
-        "behat/behat": "^3.0",
-        "behat/mink-extension": "^2.2",
+        "behat/behat": "^3.6",
+        "behat/mink": "1.7.1",
+        "behat/mink-extension": "^2.3",
         "behat/mink-goutte-driver": "^1.2",
-        "behat/mink-selenium2-driver": "dev-master",
+        "behat/mink-selenium2-driver": "^1.4",
         "jarnaiz/behat-junit-formatter": "^1.3",
         "rdx/behat-variables": "^1.2",
-        "sensiolabs/behat-page-object-extension": "^2.0",
-        "symfony/translation": "^3.4",
-        "sabre/xml": "^2.1",
+        "sensiolabs/behat-page-object-extension": "^2.3",
+        "symfony/translation": "^4.4",
+        "sabre/xml": "^2.2",
         "guzzlehttp/guzzle": "^6.5",
         "phpunit/phpunit": "^7.5"
     }


### PR DESCRIPTION
Backport #399 to `release-0.8.3` branch.
Due to upstream changes in Behat Mink dependencies, this is needed to get acceptance test CI working.