### PR TITLE
[0.8.3] Set core min-version to 10.4

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Furthermore guests are fully auditable with the [ownCloud Auditing application](
 	<licence>GPLv2</licence>
 	<author>ownCloud GmbH</author>
 	<dependencies>
-		<owncloud min-version="10.3" max-version="10" />
+		<owncloud min-version="10.4" max-version="10" />
 	</dependencies>
 	<category>collaboration</category>
 	<types>


### PR DESCRIPTION
Because of 
- #384 allow `+` in guest usernames
- #393 bump handlebars 4.1.1 to 4.7.3 (which might not play nicely with core 10.3.2?)

See discussion around https://github.com/owncloud/guests/issues/400#issuecomment-599860752 to decide if we should actually do this.