### PR TITLE
Merge back Release 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [0.8.3] - 2020-03-09
+
+### Fixed
+
+- Use rawurldecode for allowing "+" in guests emails - [#384](https://github.com/owncloud/guests/issues/384)
+- Use model addShare instead of share api while wrapping ShareDialogView - [#369](https://github.com/owncloud/guests/issues/369)
+
+### Changed
+
+- Bump libraries
 
 ## [0.8.2] - 2019-08-14
 
@@ -157,7 +166,7 @@ This release consists mostly of internal changes to adapt the guest app to ownCl
 
 - Core functionality
 
-[Unreleased]: https://github.com/owncloud/guests/compare/v0.8.2...master
+[0.8.3]: https://github.com/owncloud/guests/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/owncloud/guests/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/owncloud/guests/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/owncloud/guests/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [0.8.3] - 2020-03-09
+## [0.8.3] - 2020-03-17
 
 ### Fixed
 
@@ -13,7 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Bump libraries
+- Set core min-version to 10.4 - [#402](https://github.com/owncloud/guests/issues/402)
+- Bump libraries [#403](https://github.com/owncloud/guests/issues/403)
 
 ## [0.8.2] - 2019-08-14
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ Furthermore guests are fully auditable with the [ownCloud Auditing application](
 - Video: [ownCloud X Insights: Guest Users](https://www.youtube.com/watch?v=L42PBHgqKVI)
 	</description>
 	<namespace>Guests</namespace>
-	<version>0.8.2</version>
+	<version>0.8.3</version>
 	<documentation>
     		<user>https://doc.owncloud.com/server/latest/user_manual/files/webgui/sharing.html?highlight=guest#sharing-files-with-guest-users</user>
     	</documentation>


### PR DESCRIPTION
Because min server version has been increased to 10.4, the next guests release has to be 0.9.0
Please merge back, then I'll create a new 0.9.0 branch