### PR TITLE
Make text 'The token is invalid' more user friendly

### DIFF
--- a/lib/Controller/RegisterController.php
+++ b/lib/Controller/RegisterController.php
@@ -146,7 +146,7 @@ class RegisterController extends Controller {
 
 		if (empty($checkToken)) {
 			$errorMessages['token'] = (string)$this->l10n->t(
-				'The token is invalid'
+				'Invite has expired'
 			);
 		}
 

--- a/tests/acceptance/features/webUIGuests/guests.feature
+++ b/tests/acceptance/features/webUIGuests/guests.feature
@@ -25,7 +25,7 @@ Feature: Guests
     And guest user "guest" has registered
     When guest user "guest" registers and sets password to "secondpassword" using the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"
-    And a warning should be displayed on the set-password-page saying "The token is invalid"
+    And a warning should be displayed on the set-password-page saying "Invite has expired"
 
   @mailhog @skipOnOcV10.2 @skipOnOcV10.3
   Scenario Outline: User uses valid email to create a guest user


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Guests app. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
When creating a guest invitation, a user clicks the link after it has been expired, the message "The token is invalid" has been shown. This is not user friendly, since token is a very technical word, changed it to "Invite has expired"

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
https://github.com/owncloud/enterprise/issues/4868

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

