### PR TITLE
Added UI test scenario for blocked domains from sharing with guests

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIGuestsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGuestsContext.php
@@ -24,6 +24,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\SetPasswordPage;
+use Page\GuestsPage;
 use PHPUnit\Framework\Assert;
 use Page\FilesPage;
 
@@ -55,6 +56,12 @@ class WebUIGuestsContext extends RawMinkContext implements Context {
 	 *
 	 * @var EmailContext
 	 */
+	/**
+	 *
+	 * @var GuestsPage
+	 */
+	private $guestsPage;
+
 	private $emailContext;
 
 	/**
@@ -79,11 +86,14 @@ class WebUIGuestsContext extends RawMinkContext implements Context {
 	 * WebUIGuestsContext constructor.
 	 *
 	 * @param SetPasswordPage $setPasswordPage
+	 * @param GuestsPage $guestsPage
 	 * @param FilesPage $filesPage
+	 *
 	 */
-	public function __construct(SetPasswordPage $setPasswordPage, FilesPage $filesPage) {
+	public function __construct(SetPasswordPage $setPasswordPage, GuestsPage $guestsPage, FilesPage $filesPage) {
 		$this->setPasswordPage = $setPasswordPage;
 		$this->filesPage = $filesPage;
+		$this->guestsPage = $guestsPage;
 	}
 
 	/**
@@ -198,6 +208,34 @@ class WebUIGuestsContext extends RawMinkContext implements Context {
 		}
 		Assert::fail(
 			"could not find message with the text '$expectedMessage' on the set-password-page"
+		);
+	}
+
+	/**
+	 * @When the administrator/user browses to the guests admin settings page
+	 * @Given the administrator/user has browsed to the guests admin settings page
+	 *
+	 * @return void
+	 */
+	public function theUserBrowsesToTheGuestsAdminSettingsPage(): void {
+		$this->guestsPage->open();
+	}
+
+	/**
+	 * @Then the blocked domains from sharing with guests should set to :blockedDomains on the webUI
+	 *
+	 * @param string $blockedDomains
+	 *
+	 * @return void
+	 */
+	public function blockedDomainsFromSharingWithGuestsShouldBeSetTo(string $blockedDomains):void {
+		$blockedDomainsFromSharingWithGuests = $this->guestsPage->getBlockedDomainsFromSharingWithGuests();
+		Assert::assertEquals(
+			$blockedDomains,
+			$blockedDomainsFromSharingWithGuests,
+			__METHOD__
+			. " The blocked domains from sharing with guests was expected to be set to '$blockedDomains', "
+			. "but was actually set to '$blockedDomainsFromSharingWithGuests'"
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebUIGuestsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGuestsContext.php
@@ -86,11 +86,11 @@ class WebUIGuestsContext extends RawMinkContext implements Context {
 	 * WebUIGuestsContext constructor.
 	 *
 	 * @param SetPasswordPage $setPasswordPage
-	 * @param GuestsPage $guestsPage
 	 * @param FilesPage $filesPage
+	 * @param GuestsPage $guestsPage
 	 *
 	 */
-	public function __construct(SetPasswordPage $setPasswordPage, GuestsPage $guestsPage, FilesPage $filesPage) {
+	public function __construct(SetPasswordPage $setPasswordPage, FilesPage $filesPage, GuestsPage $guestsPage) {
 		$this->setPasswordPage = $setPasswordPage;
 		$this->filesPage = $filesPage;
 		$this->guestsPage = $guestsPage;
@@ -222,13 +222,13 @@ class WebUIGuestsContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the blocked domains from sharing with guests should set to :blockedDomains on the webUI
+	 * @Then the blocked domains from sharing with guests input should have value :blockedDomains on the webUI
 	 *
 	 * @param string $blockedDomains
 	 *
 	 * @return void
 	 */
-	public function blockedDomainsFromSharingWithGuestsShouldBeSetTo(string $blockedDomains):void {
+	public function blockedDomainsFromSharingWithGuestsInputShouldHaveValue(string $blockedDomains):void {
 		$blockedDomainsFromSharingWithGuests = $this->guestsPage->getBlockedDomainsFromSharingWithGuests();
 		Assert::assertEquals(
 			$blockedDomains,
@@ -237,6 +237,17 @@ class WebUIGuestsContext extends RawMinkContext implements Context {
 			. " The blocked domains from sharing with guests was expected to be set to '$blockedDomains', "
 			. "but was actually set to '$blockedDomainsFromSharingWithGuests'"
 		);
+	}
+
+	/**
+	 * @When the administrator sets the value of blocked domains sharing from guests input to :blockedDomains using webUI
+	 *
+	 * @param string $blockedDomains
+	 *
+	 * @return void
+	 */
+	public function adminSetsValueOfBlockedDomainsSharingFromGuestsInputTo(string $blockedDomains):void {
+		$this->guestsPage->setBlockedDomainsFromSharingWithGuests($blockedDomains);
 	}
 
 	/**

--- a/tests/acceptance/features/lib/GuestsPage.php
+++ b/tests/acceptance/features/lib/GuestsPage.php
@@ -2,8 +2,8 @@
 /**
  * ownCloud
  *
- * @author Artur Neumann <artur@jankaritech.com>
- * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
+ * @author Sagar Gurung <sagar@jankaritech.com>
+ * @copyright Copyright (c) 2017 Sagar Gurung sagar@jankaritech.com
  *
  * This code is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License,
@@ -50,5 +50,23 @@ class GuestsPage extends OwncloudPage {
 			" id $this->guestsSharingBlockDomainsInputFieldId could not find input field for blocked domains from sharing with guests"
 		);
 		return $blockedDomainsSharingWithGuests->getValue();
+	}
+
+	/**
+	 * Set the blocked domains from sharing with guests
+	 *
+	 * @param string $blockedDomains
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function setBlockedDomainsFromSharingWithGuests(string $blockedDomains): void {
+		$blockedDomainsSharingWithGuests = $this->findById($this->guestsSharingBlockDomainsInputFieldId);
+		$this->assertElementNotNull(
+			$blockedDomainsSharingWithGuests,
+			__METHOD__ .
+			" id $this->guestsSharingBlockDomainsInputFieldId could not find input field for blocked domains from sharing with guests"
+		);
+		$this->fillField($this->guestsSharingBlockDomainsInputFieldId, $blockedDomains);
 	}
 }

--- a/tests/acceptance/features/lib/GuestsPage.php
+++ b/tests/acceptance/features/lib/GuestsPage.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page;
+
+use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Session;
+use Behat\Mink\Element\NodeElement;
+
+/**
+ * page where the guests users are grouped under a virtual group in the user manager
+ */
+class GuestsPage extends OwncloudPage {
+
+	/**
+	 * @var string $path
+	 */
+	protected $path = 'index.php/settings/admin?sectionid=sharing#guests';
+	protected $guestsSharingBlockDomainsInputFieldId = 'guestSharingBlockDomains';
+
+	/**
+	 * get the blocked domains from sharing with guests
+	 *
+	 * @return string
+	 */
+	public function getBlockedDomainsFromSharingWithGuests(): string {
+		$blockedDomainsSharingWithGuests = $this->findById($this->guestsSharingBlockDomainsInputFieldId);
+		$this->assertElementNotNull(
+			$blockedDomainsSharingWithGuests,
+			__METHOD__ .
+			" id $this->guestsSharingBlockDomainsInputFieldId could not find input field for blocked domains from sharing with guests"
+		);
+		return $blockedDomainsSharingWithGuests->getValue();
+	}
+}

--- a/tests/acceptance/features/webUIGuests/guests.feature
+++ b/tests/acceptance/features/webUIGuests/guests.feature
@@ -209,8 +209,17 @@ Feature: Guests
     And the email address of user "regularUser" should be "guest@example.com"
 
   Scenario: check blocked domains set from command line for guests in webUI
-    Given the administrator has invoked occ command "config:app:set guests blockdomains --value='something.com,qwerty.org,some.gov,some.au'"
+    Given the administrator has invoked occ command "config:app:set guests blockdomains --value='something.com,qwerty.org,example.gov'"
     And user admin has logged in using the webUI
     When the administrator browses to the guests admin settings page
-    Then the blocked domains from sharing with guests should set to "something.com,qwerty.org,some.gov,some.au" on the webUI
+    Then the blocked domains from sharing with guests input should have value "something.com,qwerty.org,example.gov" on the webUI
+
+
+  Scenario: check blocked domains set from webUI for guests in command line
+    Given user admin has logged in using the webUI
+    And the administrator has browsed to the guests admin settings page
+    When the administrator sets the value of blocked domains sharing from guests input to "something.com,qwerty.org,example.gov" using webUI
+    And the administrator invokes occ command "config:app:get guests blockdomains"
+    Then the command should have been successful
+    And the command output should be the text "something.com,qwerty.org,example.gov"
 

--- a/tests/acceptance/features/webUIGuests/guests.feature
+++ b/tests/acceptance/features/webUIGuests/guests.feature
@@ -207,3 +207,10 @@ Feature: Guests
       | username    |
       | regularUser |
     And the email address of user "regularUser" should be "guest@example.com"
+
+  Scenario: check blocked domains set from command line for guests in webUI
+    Given the administrator has invoked occ command "config:app:set guests blockdomains --value='something.com,qwerty.org,some.gov,some.au'"
+    And user admin has logged in using the webUI
+    When the administrator browses to the guests admin settings page
+    Then the blocked domains from sharing with guests should set to "something.com,qwerty.org,some.gov,some.au" on the webUI
+


### PR DESCRIPTION
## Description
This PR adds UI tests for sharing settings guests bloackdomains

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/guests/issues/496

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
