### PR TITLE
for legacy hooks do not hint type

### DIFF
--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -138,7 +138,14 @@ class Hooks {
 		}
 	}
 
-	public static function extendJsConfig(array &$array): void {
+	/**
+	 * Function used to extend global JS config emited with
+	 * OC_Hook::emit('\OCP\Config', 'js', ['array' => &$array]) and available
+	 * in JS as oc_appconfig.guests
+	 *
+	 * @param array $array holding $array['array'] key with a reference value to config
+	 */
+	public static function extendJsConfig($array): void {
 		$blockDomains = \OC::$server->getConfig()->getAppValue('guests', 'blockdomains');
 
 		$array['array']['oc_appconfig']['guests'] = [


### PR DESCRIPTION
fixes https://github.com/owncloud/enterprise/issues/5193

we can hit exception as `{"reqId":"redacted","level":3,"time":"redacted","remoteAddr":"redacted","user":"--","app":"PHP","method":"GET","url":"\/core\/js\/oc.js?v=a56e4d21fce3a1c65e121c2dc61d270c","message":"Parameter 1 to OCA\\WOPI\\Hooks::extendJsConfig() expected to be a reference, value given at \/var\/www\/owncloud\/lib\/private\/legacy\/hook.php#103"}`

align with other apps like https://github.com/owncloud/core/blob/master/apps/files/lib/App.php#L46