### PR TITLE
[tests-only] [full-ci] Do not test with S3 and core latest 10.10

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -79,6 +79,9 @@ config = {
             "suites": {
                 "apiGuests": "apiGuestsScality",
             },
+            "servers": [
+                "daily-master-qa",
+            ],
             "databases": [
                 "mysql:8.0",
             ],
@@ -89,6 +92,9 @@ config = {
             "suites": {
                 "apiGuests": "apiGuestsCeph",
             },
+            "servers": [
+                "daily-master-qa",
+            ],
             "databases": [
                 "mysql:8.0",
             ],


### PR DESCRIPTION
## Description
`files_primary_s3` `master` now has the code for the Guzzle7 major version change. So we know that it does not work with core "latest" 10.10. So do not test that combination.

## Related Issue
Part of https://github.com/owncloud/core/issues/39387

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

