### PR TITLE
Provide extended attributes when the event is emitted

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -106,7 +106,6 @@ config = {
         "acceptance": {
             "servers": [
                 "daily-master-qa",
-                "latest",
             ],
         },
     },

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -99,22 +99,27 @@ class Application extends App {
 	private function addUserAppAttributes(IServerContainer $server, UserExtendedAttributesEvent $attributesEvent, $userAppAttributes) {
 		$user = $attributesEvent->getUser();
 		$isGuestUser = $server->getConfig()->getUserValue($user->getUID(), 'owncloud', 'isGuest', '0');
-		if ($isGuestUser !== '0') {
-			$appWhiteList = AppWhitelist::getWhitelist();
+		if ($isGuestUser === '0') {
+			return;
+		}
+		$appWhiteList = AppWhitelist::getWhitelist();
 
-			/**
-			 * Add whitelistedAppsForGuests attribute if it is not present. There is a
-			 * case where the whitelistedAppsForGuests could be changed by the admin.
-			 * Under such circumstance, if the whiteListedApp is present in
-			 * userAppAttributes array we have to update it.
-			 */
-			if (!isset($userAppAttributes['whitelistedAppsForGuests']) ||
-				$userAppAttributes['whitelistedAppsForGuests'] !== $appWhiteList) {
-				if ($attributesEvent->setAttributes('whitelistedAppsForGuests', $appWhiteList)) {
-					$server->getLogger()->debug("Add new user attributes key = whiteListedApps and value = " . \implode(',', $appWhiteList) . " for guest user " . $user->getUID());
-				} else {
-					$server->getLogger()->debug("The attributes key = whiteListedApps already exist for guest user " . $user->getUID());
-				}
+		/**
+		 * Add whitelistedAppsForGuests attribute if it is not present. There is a
+		 * case where the whitelistedAppsForGuests could be changed by the admin.
+		 * Under such circumstance, if the whiteListedApp is present in
+		 * userAppAttributes array we have to update it.
+		 */
+		if (!isset($userAppAttributes['whitelistedAppsForGuests']) ||
+			$userAppAttributes['whitelistedAppsForGuests'] !== $appWhiteList) {
+			if ($attributesEvent->setAttributes('whitelistedAppsForGuests', $appWhiteList)) {
+				$server->getLogger()->debug(
+					"Add new user attributes key 'whitelistedAppsForGuests' has value '" . \implode(',', $appWhiteList) . "' for guest user " . $user->getUID()
+				);
+			} else {
+				$server->getLogger()->debug(
+					"The attributes key 'whitelistedAppsForGuests' already exists for guest user " . $user->getUID()
+				);
 			}
 		}
 	}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -105,22 +105,24 @@ class Application extends App {
 		$appWhiteList = AppWhitelist::getWhitelist();
 
 		/**
-		 * Add whitelistedAppsForGuests attribute if it is not present. There is a
+		 * Add whitelistedAppsForGuests attribute only if it is not present. There is a
 		 * case where the whitelistedAppsForGuests could be changed by the admin.
 		 * Under such circumstance, if the whiteListedApp is present in
 		 * userAppAttributes array we have to update it.
 		 */
-		if (!isset($userAppAttributes['whitelistedAppsForGuests']) ||
-			$userAppAttributes['whitelistedAppsForGuests'] !== $appWhiteList) {
-			if ($attributesEvent->setAttributes('whitelistedAppsForGuests', $appWhiteList)) {
-				$server->getLogger()->debug(
-					"Add new user attributes key 'whitelistedAppsForGuests' has value '" . \implode(',', $appWhiteList) . "' for guest user " . $user->getUID()
-				);
-			} else {
-				$server->getLogger()->debug(
-					"The attributes key 'whitelistedAppsForGuests' already exists for guest user " . $user->getUID()
-				);
-			}
+		if (isset($userAppAttributes['whitelistedAppsForGuests']) &&
+			$userAppAttributes['whitelistedAppsForGuests'] === $appWhiteList) {
+			return;
+		}
+
+		if ($attributesEvent->setAttributes('whitelistedAppsForGuests', $appWhiteList)) {
+			$server->getLogger()->debug(
+				"Add new user attributes key 'whitelistedAppsForGuests' has value '" . \implode(',', $appWhiteList) . "' for guest user " . $user->getUID()
+			);
+		} else {
+			$server->getLogger()->debug(
+				"The attributes key 'whitelistedAppsForGuests' already exists for guest user " . $user->getUID()
+			);
 		}
 	}
 


### PR DESCRIPTION
## Description

Provide extended attributes when the event is emitted.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

Rebase of #371 

## Related Issue

#516 

## How Has This Been Tested?
Manually set the apps whitelist in guests to include and exclude each of
- customgroups
- systemtags
- comments
- files_versions
- files_texteditor

And check that the corresponding functionality in the classic webUI is not displayed for a guest user when the app is not whitelisted.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
