### PR TITLE
set core min-version 10.11 for extended-attributes

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Furthermore guests are fully auditable with the [ownCloud Auditing application](
 	<licence>GPLv2</licence>
 	<author>ownCloud GmbH</author>
 	<dependencies>
-		<owncloud min-version="10.4" max-version="10" />
+		<owncloud min-version="10.11" max-version="10" />
 	</dependencies>
 	<category>collaboration</category>
 	<types>


### PR DESCRIPTION
## Description
PR #518 uses `UserExtendedAttributesEvent` that is added in core 10.11.0. So the next 0.12.0 release of the guests app needs core min-version set to 10.11

## Related Issue
#516 #520

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

