### PR TITLE
Add encryption and files_primary_s3 to CORE_WHITELIST

### DIFF
--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -30,7 +30,7 @@ use OCP\Template;
  * @package OCA\Guests
  */
 class AppWhitelist {
-	public const CORE_WHITELIST = ',core,encryption,files,files_primary_s3,guests';
+	public const CORE_WHITELIST = ',core,admin_audit,encryption,files,files_antivirus,files_primary_s3,firewall,guests,ransomware_protection';
 	public const DEFAULT_WHITELIST = 'settings,avatar,files_external,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications,password_policy,oauth2,files_pdfviewer,files_mediaviewer,richdocuments,onlyoffice,wopi,oco_selfservice,twofactor_totp';
 
 	public static function preSetup($params) {

--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -30,7 +30,7 @@ use OCP\Template;
  * @package OCA\Guests
  */
 class AppWhitelist {
-	public const CORE_WHITELIST = ',core,files,guests';
+	public const CORE_WHITELIST = ',core,encryption,files,files_primary_s3,guests';
 	public const DEFAULT_WHITELIST = 'settings,avatar,files_external,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications,password_policy,oauth2,files_pdfviewer,files_mediaviewer,richdocuments,onlyoffice,wopi,oco_selfservice,twofactor_totp';
 
 	public static function preSetup($params) {

--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -30,7 +30,7 @@ use OCP\Template;
  * @package OCA\Guests
  */
 class AppWhitelist {
-	public const CORE_WHITELIST = ',core,admin_audit,encryption,files,files_antivirus,files_primary_s3,firewall,guests,ransomware_protection';
+	public const CORE_WHITELIST = ',core,admin_audit,encryption,files,files_antivirus,files_external_s3,files_primary_s3,firewall,guests,ransomware_protection';
 	public const DEFAULT_WHITELIST = 'settings,avatar,files_external,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications,password_policy,oauth2,files_pdfviewer,files_mediaviewer,richdocuments,onlyoffice,wopi,oco_selfservice,twofactor_totp';
 
 	public static function preSetup($params) {


### PR DESCRIPTION
## Description
If encryption is used in an installation then it really needs to be always in the whitelisted apps for a guest, otherwise a guest is going to have trouble saving a file.

Similarly if files_primary_s3 is used in an installation then it really needs to be always in the whitelisted apps for a guest, otherwise a guest is going to have trouble saving a file.

So I think that these should be always part of the "core" whitelisted apps. There is not functionality that can be sensibly/usefully enabled and disabled for a guest user in these apps.

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

