### PR TITLE
[tests-only] [full-ci] Change mailhog test tag to email

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,6 +1,6 @@
 BANST_AWS_CLI = "banst/awscli"
 DRONE_CLI = "drone/cli:alpine"
-MAILHOG_MAILHOG = "mailhog/mailhog"
+INBUCKET_INBUCKET = "inbucket/inbucket"
 MINIO_MC = "minio/mc:RELEASE.2020-12-18T10-53-53Z"
 OC_CI_ALPINE = "owncloudci/alpine:latest"
 OC_CI_BAZEL_BUILDIFIER = "owncloudci/bazel-buildifier"
@@ -1146,7 +1146,7 @@ def acceptance(ctx):
                         makeParameter = "test-acceptance-cli"
 
                 if testConfig["emailNeeded"]:
-                    environment["MAILHOG_HOST"] = "email"
+                    environment["EMAIL_HOST"] = "email"
 
                 if testConfig["ldapNeeded"]:
                     environment["TEST_WITH_LDAP"] = True
@@ -1465,7 +1465,7 @@ def emailService(emailNeeded):
     if emailNeeded:
         return [{
             "name": "email",
-            "image": MAILHOG_MAILHOG,
+            "image": INBUCKET_INBUCKET,
         }]
 
     return []
@@ -1476,7 +1476,7 @@ def waitForEmailService(emailNeeded):
             "name": "wait-for-email",
             "image": OC_CI_WAIT_FOR,
             "commands": [
-                "wait-for -it email:8025 -t 600",
+                "wait-for -it email:9000 -t 600",
             ],
         }]
 

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -46,7 +46,7 @@ Feature: Guests
     And as "guest@example.com" file "/textfile.txt" should not exist
     And as "Alice" file "/textfile.txt" should not exist
 
-  @mailhog @skipOnOcV10.3
+  @email @skipOnOcV10.3
   Scenario Outline: A guest user can upload files to a folder shared with them
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "<user>" with email "<email-address>"
@@ -63,7 +63,7 @@ Feature: Guests
       | John.Smith@email.com           | John.Smith           |
       | betty_anne+bob-burns@email.com | betty_anne+bob-burns |
 
-  @mailhog
+  @email
   Scenario: A guest user can upload chunked files to a folder shared with them
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -79,7 +79,7 @@ Feature: Guests
     Then as "guest@example.com" file "/tmp/myChunkedFile.txt" should exist
     And as "Alice" file "/tmp/myChunkedFile.txt" should exist
 
-  @mailhog @issue-279
+  @email @issue-279
   Scenario: A guest user can upload files to a folder shared with them
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -104,7 +104,7 @@ Feature: Guests
     Cheers.
     """
 
-  @mailhog
+  @email
   Scenario: A guest user can upload files to a folder shared with them (async upload)
     Given the administrator has enabled async operations
     And user "Alice" has been created with default attributes and small skeleton files
@@ -129,7 +129,7 @@ Feature: Guests
     Cheers.
     """
 
-  @mailhog
+  @email
   Scenario: A guest user can cancel a chunked upload
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -145,7 +145,7 @@ Feature: Guests
     Then the HTTP status code should be "204"
     And as "Alice" file "/tmp/myChunkedFile.txt" should not exist
 
-  @mailhog
+  @email
   Scenario: A guest user can upload a file and can reshare it
     Given these users have been created with default attributes and small skeleton files:
       | username |
@@ -162,7 +162,7 @@ Feature: Guests
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
 
-  @mailhog
+  @email
   Scenario: A guest user cannot reshare files
     Given these users have been created with default attributes and small skeleton files:
       | username |
@@ -185,7 +185,7 @@ Feature: Guests
     Then the OCS status code should be "404"
     And the HTTP status code should be "200"
 
-  @mailhog
+  @email
   Scenario: A created guest user can log in
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -216,7 +216,7 @@ Feature: Guests
     Then the OCS status code should be "100"
     And user "guest@example.com" should not belong to group "guests_app"
 
-  @mailhog
+  @email
   Scenario: A guest user can not create new guest users
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -226,7 +226,7 @@ Feature: Guests
     When user "guest@example.com" attempts to create guest user "guest2" with email "guest2@example.com" using the API
     Then the HTTP status code should be "403"
 
-  @mailhog
+  @email
   Scenario: Create a regular user using the same email address as an existing guest user
     Given the administrator has created guest user "guest" with email "guest@example.com"
     When the administrator creates these users with skeleton files:

--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -403,6 +403,7 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 		string $guestDisplayName,
 		string $guestEmail
 	): void {
+		$this->featureContext->pushEmailRecipientAsMailBox($guestEmail);
 		$this->userCreatesAGuestUser(
 			$this->featureContext->getAdminUsername(),
 			$guestDisplayName,

--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -513,7 +513,6 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 	 */
 	public function getRegistrationUrl(string $address): string {
 		$lastEmailBody = EmailHelper::getBodyOfLastEmail(
-			$this->emailContext->getLocalMailhogUrl(),
 			$address,
 			$this->featureContext->getStepLineRef()
 		);

--- a/tests/acceptance/features/webUIGuests/guests.feature
+++ b/tests/acceptance/features/webUIGuests/guests.feature
@@ -5,7 +5,7 @@ Feature: Guests
     Given using OCS API version "1"
     And using new dav path
 
-  @mailhog
+  @email
   Scenario: Guest user sets its own password
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -16,7 +16,7 @@ Feature: Guests
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
     And folder "tmp" should be listed on the webUI
 
-  @mailhog
+  @email
   Scenario: Guest user uses the link twice
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -27,7 +27,7 @@ Feature: Guests
     Then the user should be redirected to a webUI page with the title "%productname%"
     And a warning should be displayed on the set-password-page saying "The token is invalid"
 
-  @mailhog @skipOnOcV10.2 @skipOnOcV10.3
+  @email @skipOnOcV10.2 @skipOnOcV10.3
   Scenario Outline: User uses valid email to create a guest user
     Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
@@ -39,7 +39,7 @@ Feature: Guests
       | John.Smith@email.com           |
       | Betty_Anne+Bob-Burns@email.com |
 
-  @mailhog
+  @email
   Scenario: User uses some random string email to create a guest user
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has logged in using the webUI
@@ -49,7 +49,7 @@ Feature: Guests
     And user "somestring" should not be displayed in the dropdown as a guest user
     And user "somestring" should not exist
 
-  @mailhog @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @email @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: User cannot use an email of a blocked domain to create a guest user
     Given the administrator has added config key "blockdomains" with value "<block-domains>" in app "guests"
     And user "Alice" has been created with default attributes and small skeleton files
@@ -64,7 +64,7 @@ Feature: Guests
       | gmail.com,somewhere.org          |
       | test.com,gmail.com,somewhere.org |
 
-  @mailhog @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @email @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: User can use an email of a not-blocked domain to create a guest user
     Given the administrator has added config key "blockdomains" with value "test.com,gmail.com" in app "guests"
     And user "Alice" has been created with default attributes and small skeleton files
@@ -72,7 +72,7 @@ Feature: Guests
     When the user shares file "textfile0.txt" with guest user with email "valid@email.com" using the webUI
     Then user "valid@email.com" should exist
 
-  @mailhog @skipOnOcV10.2
+  @email @skipOnOcV10.2
   Scenario: User uses invalid email to create a guest user
     Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
@@ -82,7 +82,7 @@ Feature: Guests
       | Error | Invalid mail address |
     And user "invalid@email.com()9876a" should not exist
 
-  @mailhog @skipOnOcV10.2
+  @email @skipOnOcV10.2
   Scenario: User tries to create a guest user via email with an already used email
     Given these users have been created with large skeleton files:
       | username | email        |
@@ -94,7 +94,7 @@ Feature: Guests
     Then user "Brian" should be listed in the autocomplete list on the webUI
     And user "Brian@oc.com" should not be displayed in the dropdown as a guest user
 
-  @mailhog @issue-329 @skipOnOcV10.2
+  @email @issue-329 @skipOnOcV10.2
   Scenario: User tries to create a guest user when a server email mode is not set
     Given user "Brian" has been created with default attributes and large skeleton files
     And user "Brian" has logged in using the webUI
@@ -106,7 +106,7 @@ Feature: Guests
     And user "valid@email.com" should exist
     # And user "valid@email.com" should not exist
 
-  @mailhog @skipOnOcV10.2 @skipOnFIREFOX
+  @email @skipOnOcV10.2 @skipOnFIREFOX
   Scenario: Administrator changes the guest user's password in users menu
     Given user "admin" has uploaded file with content "new content" to "new-file.txt"
     And the administrator has logged in using the webUI
@@ -119,7 +119,7 @@ Feature: Guests
     And the user logs in with username "valid@email.com" and password "newpassword" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
-  @mailhog @issue-329 @skipOnOcV10.2
+  @email @issue-329 @skipOnOcV10.2
   Scenario: User tries to create a guest user when a server email is invalid
     Given user "Brian" has been created with default attributes and large skeleton files
     And user "Brian" has logged in using the webUI
@@ -131,7 +131,7 @@ Feature: Guests
     And user "valid@email.com" should exist
     # And user "valid@email.com" should not exist
 
-  @mailhog @skipOnOcV10.2
+  @email @skipOnOcV10.2
   Scenario: Administrator deletes a guest user in user's menu
     Given user "admin" has uploaded file with content "new content" to "new-file.txt"
     And the administrator has logged in using the webUI
@@ -140,7 +140,7 @@ Feature: Guests
     When the administrator deletes user "valid@email.com" using the webUI and confirms the deletion using the webUI
     Then user "valid@email.com" should not exist
 
-  @mailhog @skipOnOcV10.2
+  @email @skipOnOcV10.2
   Scenario Outline: User creates a guest user with email that contains capital letters
     Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
@@ -158,7 +158,7 @@ Feature: Guests
       | USER@example.com | USER@example.com | user@example.com |
       | user@example.com | USER@example.com | user@EXAMPLE.com |
 
-  @mailhog
+  @email
   Scenario: Guest user is not able to upload or create files
     Given user "Alice" has been created with default attributes and large skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -167,7 +167,7 @@ Feature: Guests
     And user "guest@example.com" logs in using the webUI
     Then the user should not have permission to upload or create files
 
-  @mailhog @skipOnOcV10.3
+  @email @skipOnOcV10.3
   Scenario Outline: Guest user is able to upload or create files inside the received share(with change permission)
     Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
@@ -185,7 +185,7 @@ Feature: Guests
       | John.Smith@email.com           |
       | Betty_Anne+Bob-Burns@email.com |
 
-  @mailhog
+  @email
   Scenario: Guest user tries to upload or create files inside the received share(read only permission)
     Given user "Alice" has been created with default attributes and large skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -197,7 +197,7 @@ Feature: Guests
     And the user opens folder "simple-folder" using the webUI
     Then the user should not have permission to upload or create files
 
-  @mailhog
+  @email
   Scenario: Create a regular user using the same email address of an existing guest user
     Given the administrator has created guest user "guest" with email "guest@example.com"
     And the administrator has logged in using the webUI


### PR DESCRIPTION
https://github.com/owncloud/core/pull/40442 changed the email server used in tests from mailhog to inbucket. It also changed the tag used in feature files from `@mailhog` to `@email`

So make the same change here in the guests app.

Issue https://github.com/owncloud/QA/issues/771
