### PR TITLE
Extend whitelists

### DIFF
--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -30,8 +30,8 @@ use OCP\Template;
  * @package OCA\Guests
  */
 class AppWhitelist {
-	public const CORE_WHITELIST = ',core,admin_audit,encryption,files,files_antivirus,files_external_s3,files_primary_s3,firewall,guests,ransomware_protection';
-	public const DEFAULT_WHITELIST = 'settings,avatar,files_external,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications,password_policy,oauth2,files_pdfviewer,files_mediaviewer,richdocuments,onlyoffice,wopi,oco_selfservice,twofactor_totp';
+	public const CORE_WHITELIST = ',core,files,guests,encryption,files_primary_s3,files_antivirus,files_external,files_external_dropbox,files_external_ftp,files_ldap_home,files_onedrive,sharepoint,files_external_s3,admin_audit,firewall,ransomware_protection';
+	public const DEFAULT_WHITELIST = 'settings,avatar,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications,password_policy,oauth2,files_pdfviewer,files_mediaviewer,richdocuments,onlyoffice,wopi,oco_selfservice,twofactor_totp,windows_network_drive';
 
 	public static function preSetup($params) {
 		$uid = $params['user'];

--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -30,8 +30,8 @@ use OCP\Template;
  * @package OCA\Guests
  */
 class AppWhitelist {
-	public const CORE_WHITELIST = ',core,files,guests,encryption,files_primary_s3,files_antivirus,files_external,files_external_dropbox,files_external_ftp,files_ldap_home,files_onedrive,sharepoint,files_external_s3,admin_audit,firewall,ransomware_protection';
-	public const DEFAULT_WHITELIST = 'settings,avatar,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications,password_policy,oauth2,files_pdfviewer,files_mediaviewer,richdocuments,onlyoffice,wopi,oco_selfservice,twofactor_totp,windows_network_drive';
+	public const CORE_WHITELIST = ',core,files,guests,encryption,files_primary_s3,files_antivirus,files_external,files_external_dropbox,files_external_ftp,files_ldap_home,files_onedrive,sharepoint,files_external_s3,windows_network_drive,admin_audit,firewall,ransomware_protection';
+	public const DEFAULT_WHITELIST = 'settings,avatar,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications,password_policy,oauth2,files_pdfviewer,files_mediaviewer,richdocuments,onlyoffice,wopi,oco_selfservice,twofactor_totp';
 
 	public static function preSetup($params) {
 		$uid = $params['user'];


### PR DESCRIPTION
## Description
Extend whitelists

## Related Issue

- https://github.com/owncloud/core/issues/40441
- https://github.com/owncloud/enterprise/issues/5428

## Motivation and Context
Extend whitelists to make enabled apps available for guest users. Some apps should not be removed from the default whitelist (which is editable by the admin) therefore they are now hard-coded in the core whitelist.

## How Has This Been Tested?
Manually by enabling such apps as admin and make sure functionalities provided by those apps are also available for guest users.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

