### PR TITLE
[tests-only][[full-ci] Added webUI acceptance tests for comments panel visibility

### DIFF
--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -242,7 +242,7 @@ Feature: Guests
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has shared file "/textfile0.txt" with user "guest@example.com"
     And guest user "guest" has registered
-    And parameter "usewhitelist" of app "guests" has been set to "true"
+    And the administrator has limited the guest access to the default whitelist apps
     And the administrator has removed the app "files_versions" from the whitelist for the guest user
     When user "guest@example.com" gets the version metadata of file "textfile0.txt"
     Then the HTTP status code should be "207"
@@ -256,7 +256,7 @@ Feature: Guests
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has shared file "/textfile0.txt" with user "guest@example.com"
     And guest user "guest" has registered
-    And parameter "usewhitelist" of app "guests" has been set to "true"
+    And the administrator has limited the guest access to the default whitelist apps
     And the administrator has removed the app "files_versions" from the whitelist for the guest user
     When user "guest@example.com" uploads file with content "some new content" to "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"

--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -699,6 +699,30 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @param string $app
+	 *
+	 * @return void
+	 */
+	public function addAppToWhiteList(string $app): void {
+		$whiteList = $this->getWhiteListApps();
+		$whiteList = explode(",", trim($whiteList));
+		if (!\in_array($app, $whiteList)) {
+			$appsList[] = $app;
+		}
+		$whiteList = join(",", $whiteList);
+		AppConfigHelper::modifyAppConfig(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			"guests",
+			"whitelist",
+			$whiteList,
+			$this->featureContext->getStepLineRef(),
+			$this->featureContext->getOcsApiVersion()
+		);
+	}
+
+	/**
 	 * @Given the administrator has removed the app :app from the whitelist for the guest user
 	 *
 	 * @param string $app
@@ -707,5 +731,16 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 	 */
 	public function theAdministratorHasRemovedAppFromTheWhitelistForGuestUser(string $app) : void {
 		$this->removeAppFromWhiteList($app);
+	}
+
+	/**
+	 * @Given the administrator has added the app :app to the whitelist for the guest user
+	 *
+	 * @param string $app
+	 *
+	 * @return void
+	 */
+	public function theAdministratorHasAddedAppToTheWhitelistForGuestUser(string $app) : void {
+		$this->addAppToWhiteList($app);
 	}
 }

--- a/tests/acceptance/features/webUIGuests/guests.feature
+++ b/tests/acceptance/features/webUIGuests/guests.feature
@@ -224,3 +224,32 @@ Feature: Guests
     Then the command should have been successful
     And the command output should be the text "something.com,qwerty.org,example.gov"
 
+  @email
+  Scenario: The comments panel should be visible
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And the administrator has created guest user "guest" with email "guest@example.com"
+    And user "Alice" has uploaded file with content "new content" to "TEXTFILE.txt"
+    And user "Alice" has shared file "/TEXTFILE.txt" with user "guest@example.com" with permissions "read"
+    And parameter "usewhitelist" of app "guests" has been set to "true"
+    And the administrator has added the app "comments" to the whitelist for the guest user
+    When guest user "guest" registers and sets password to "password" using the webUI
+    And user "guest@example.com" logs in using the webUI
+    And the user opens the file action menu of file "TEXTFILE.txt" on the webUI
+    And the user clicks the details file action on the webUI
+    Then the details dialog should be visible on the webUI
+    And the "comments" details panel should be visible
+
+  @email
+  Scenario: The comments panel should not be visible
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And the administrator has created guest user "guest" with email "guest@example.com"
+    And user "Alice" has uploaded file with content "new content" to "TEXTFILE.txt"
+    And user "Alice" has shared file "/TEXTFILE.txt" with user "guest@example.com" with permissions "read"
+    And parameter "usewhitelist" of app "guests" has been set to "true"
+    And the administrator has removed the app "comments" from the whitelist for the guest user
+    When guest user "guest" registers and sets password to "password" using the webUI
+    And user "guest@example.com" logs in using the webUI
+    And the user opens the file action menu of file "TEXTFILE.txt" on the webUI
+    And the user clicks the details file action on the webUI
+    Then the details dialog should be visible on the webUI
+    And the "comments" details panel should not be visible

--- a/tests/acceptance/features/webUIGuests/guests.feature
+++ b/tests/acceptance/features/webUIGuests/guests.feature
@@ -225,31 +225,31 @@ Feature: Guests
     And the command output should be the text "something.com,qwerty.org,example.gov"
 
   @email
-  Scenario: The comments panel should be visible
+  Scenario: check comments panel when comments app is whitelisted
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
-    And user "Alice" has uploaded file with content "new content" to "TEXTFILE.txt"
-    And user "Alice" has shared file "/TEXTFILE.txt" with user "guest@example.com" with permissions "read"
-    And parameter "usewhitelist" of app "guests" has been set to "true"
+    And user "Alice" has uploaded file with content "new content" to "lorem.txt"
+    And user "Alice" has shared file "/lorem.txt" with user "guest@example.com"
+    And the administrator has limited the guest access to the default whitelist apps
     And the administrator has added the app "comments" to the whitelist for the guest user
-    When guest user "guest" registers and sets password to "password" using the webUI
-    And user "guest@example.com" logs in using the webUI
-    And the user opens the file action menu of file "TEXTFILE.txt" on the webUI
+    And guest user "guest" has registered
+    And user "guest@example.com" has logged in using the webUI
+    When the user opens the file action menu of file "lorem.txt" on the webUI
     And the user clicks the details file action on the webUI
     Then the details dialog should be visible on the webUI
     And the "comments" details panel should be visible
 
   @email
-  Scenario: The comments panel should not be visible
+  Scenario: check comments panel when comments app is not whitelisted
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
-    And user "Alice" has uploaded file with content "new content" to "TEXTFILE.txt"
-    And user "Alice" has shared file "/TEXTFILE.txt" with user "guest@example.com" with permissions "read"
-    And parameter "usewhitelist" of app "guests" has been set to "true"
+    And user "Alice" has uploaded file with content "new content" to "lorem.txt"
+    And user "Alice" has shared file "/lorem.txt" with user "guest@example.com"
+    And the administrator has limited the guest access to the default whitelist apps
     And the administrator has removed the app "comments" from the whitelist for the guest user
-    When guest user "guest" registers and sets password to "password" using the webUI
-    And user "guest@example.com" logs in using the webUI
-    And the user opens the file action menu of file "TEXTFILE.txt" on the webUI
+    And guest user "guest" has registered
+    And user "guest@example.com" has logged in using the webUI
+    When the user opens the file action menu of file "lorem.txt" on the webUI
     And the user clicks the details file action on the webUI
     Then the details dialog should be visible on the webUI
     And the "comments" details panel should not be visible


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Guests app. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
This PR adds test scenarios for the comments panel visibility when the `comments` app is whitelisted and `comments` app is removed from whitelist.

## Related Issue
- Reltated to 
https://github.com/owncloud/guests/issues/523

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

