### PR TITLE
[tests-only][full-ci] bug demo test for removing files_trashbin app from whitelist for guest user

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -19,6 +19,8 @@ default:
         - CommentsContext:
         - WebDavPropertiesContext:
         - TagsContext:
+        - TrashbinContext:
+        - OccContext:
 
     webUIGuests:
       paths:

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -476,8 +476,53 @@ Feature: Guests
     And the administrator has removed the app "comments" from the whitelist for the guest user
     When user "guest@example.com" deletes the last created comment using the WebDAV API
     Then the HTTP status code should be "204"
-    # uncomment the line above and remove the line above when issue-549 is fixed
+    # uncomment the line below and remove the line above when issue-549 is fixed
     #Then the HTTP status code should be "403"
+
+  @email @issue-553
+  Scenario: files inside shared folder deleted by guest user is available in sharer trashbin when files_trashbin app is whitelisted
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And the administrator has created guest user "guest" with email "guest@example.com"
+    And user "Alice" has created folder "/tmp"
+    And user "Alice" has uploaded file with content "some content" to "/tmp/textfile0.txt"
+    And user "Alice" has shared folder "/tmp" with user "guest@example.com"
+    And guest user "guest" has registered
+    And the administrator has limited the guest access to the default whitelist apps
+    And the administrator has added the app "files_trashbin" to the whitelist for the guest user
+    When user "guest@example.com" deletes file "/tmp/textfile0.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" file "/tmp/textfile0.txt" should not exist
+    When user "Alice" tries to list the trashbin content for user "Alice"
+    Then the HTTP status code should be "207"
+    And as "Alice" the file with original path "/tmp/textfile0.txt" should exist in the trashbin
+
+  @email @issue-553
+  Scenario: a guest user can delete shared files when files_trashbin app is whitelisted
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And the administrator has created guest user "guest" with email "guest@example.com"
+    And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
+    And user "Alice" has shared file "/textfile0.txt" with user "guest@example.com"
+    And guest user "guest" has registered
+    And the administrator has limited the guest access to the default whitelist apps
+    And the administrator has added the app "files_trashbin" to the whitelist for the guest user
+    When user "guest@example.com" deletes file "/textfile0.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" file "/textfile0.txt" should exist
+    And as "guest@example.com" file "/textfile0.txt" should not exist
+
+  @email @issue-553
+  Scenario: a guest user cannot delete shared files when files_trashbin app is not whitelisted
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And the administrator has created guest user "guest" with email "guest@example.com"
+    And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
+    And user "Alice" has shared file "/textfile0.txt" with user "guest@example.com"
+    And guest user "guest" has registered
+    And the administrator has limited the guest access to the default whitelist apps
+    And the administrator has removed the app "files_trashbin" from the whitelist for the guest user
+    When user "guest@example.com" deletes file "/textfile0.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" file "/textfile0.txt" should exist
+    And as "guest@example.com" file "/textfile0.txt" should not exist
 
   @email @issue-551
   Scenario: a guest user cannot add tags on resource when systemtags app is not whitelisted


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Guests app. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
This PR adds test for bug demonstration for adding and removing `files_trashbin` from whilelist for guest user, to check if the guest user are able to delete the shared files and if the deleted files are available in the trashbin.

## Related Issue
Related to issue: https://github.com/owncloud/guests/issues/553

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test added

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

