### PR TITLE
[tests-only][full-ci]Fix guest creation in API step

### DIFF
--- a/tests/acceptance/features/bootstrap/GuestsContext.php
+++ b/tests/acceptance/features/bootstrap/GuestsContext.php
@@ -350,7 +350,6 @@ class GuestsContext implements Context, SnippetAcceptingContext {
 			$this->featureContext->getPasswordForUser($userName),
 			$guestDisplayName,
 			$guestEmail,
-			null,
 			$shouldExist
 		);
 	}


### PR DESCRIPTION
### Description
Previous function addUserToCreatedUsersList contains $userId
```
public function addUserToCreatedUsersList(
		?string $user,
		?string $password,
		?string $displayName = null,
		?string $email = null,
                ?string $userId = null,
		bool $shouldExist = true
	):
```
but current code does not contains the parameter `$userId`,
So removing it for the calling function in this PR.

### Related issue:
https://github.com/owncloud/guests/issues/580