### PR TITLE
[full-ci] Remove EventDispatcherInterface::dispatch from phpstan ignoreErrors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,6 @@ parameters:
     - %currentWorkingDirectory%/appinfo/Migrations/*.php
     - %currentWorkingDirectory%/appinfo/routes.php
   ignoreErrors:
-    - '#Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required.#'
     -
       message: '#Property OCA\\Guests\\Controller\\RegisterController::\$groupManager is never read, only written.#'
       path: lib/Controller/RegisterController.php


### PR DESCRIPTION
Fixes #585 

Now that Symfony5 is in core, phpstan understands the correct parameter order for EventDispatcherInterface::dispatch
The entry in ignoreErrors is no longer needed.