### PR TITLE
[tests-only] Add test scenario to check that guests work when share_folder is used

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -939,7 +939,6 @@ def acceptance(ctx):
         "skip": False,
         "debugSuites": [],
         "skipExceptParts": [],
-        "earlyFail": True,
         "enableApp": True,
         "selUserNeeded": False,
     }
@@ -976,14 +975,6 @@ def acceptance(ctx):
 
             if params["skip"]:
                 continue
-
-            # switch off earlyFail if the PR title contains full-ci
-            if ("full-ci" in ctx.build.title.lower()):
-                params["earlyFail"] = False
-
-            # switch off earlyFail when running cron builds (for example, nightly CI)
-            if (ctx.build.event == "cron"):
-                params["earlyFail"] = False
 
             if "externalScality" in params and len(params["externalScality"]) != 0:
                 # We want to use an external scality server for this pipeline.

--- a/.drone.star
+++ b/.drone.star
@@ -21,7 +21,6 @@ PLUGINS_SLACK = "plugins/slack:1"
 SELENIUM_STANDALONE_CHROME_DEBUG = "selenium/standalone-chrome-debug:3.141.59-oxygen"
 SELENIUM_STANDALONE_FIREFOX_DEBUG = "selenium/standalone-firefox-debug:3.8.1"
 SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli"
-THEGEEKLAB_DRONE_GITHUB_COMMENT = "thegeeklab/drone-github-comment:1"
 
 DEFAULT_PHP_VERSION = "7.4"
 DEFAULT_NODEJS_VERSION = "14"
@@ -1197,7 +1196,7 @@ def acceptance(ctx):
                                          "path": "%s/downloads" % dir["server"],
                                      }],
                                  }),
-                             ] + testConfig["extraTeardown"] + githubComment(params["earlyFail"]),
+                             ] + testConfig["extraTeardown"],
                     "services": databaseService(testConfig["database"]) +
                                 browserService(testConfig["browser"]) +
                                 emailService(testConfig["emailNeeded"]) +
@@ -2023,33 +2022,6 @@ def buildTestConfig(params):
                             config["runPart"] = runPart
                             configs.append(config)
     return configs
-
-def githubComment(earlyFail):
-    if (earlyFail):
-        return [{
-            "name": "github-comment",
-            "image": THEGEEKLAB_DRONE_GITHUB_COMMENT,
-            "pull": "if-not-exists",
-            "settings": {
-                "message": ":boom: Acceptance tests pipeline <strong>${DRONE_STAGE_NAME}</strong> failed. The build has been cancelled.\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER}",
-                "key": "pr-${DRONE_PULL_REQUEST}",
-                "update": "true",
-                "api_key": {
-                    "from_secret": "github_token",
-                },
-            },
-            "when": {
-                "status": [
-                    "failure",
-                ],
-                "event": [
-                    "pull_request",
-                ],
-            },
-        }]
-
-    else:
-        return []
 
 def checkStarlark():
     return [{

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -572,9 +572,9 @@ Feature: Guests
     #Then the HTTP status code should be "403"
 
   @email @skipOnOcV10.11 @skipOnOcV10.12
-  Scenario: A guest user can upload files to a folder shared with them when share_folder is in use
+  Scenario: guest user can upload files to a folder shared with them when share_folder is in use
     Given the administrator has set the default folder for received shares to "Shares"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest1" with email "guest1@example.com"
     And the HTTP status code should be "201"
     And user "Alice" has created folder "/tmp"

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -570,3 +570,16 @@ Feature: Guests
     Then the HTTP status code should be "404"
     # uncomment the line below and remove the line above when issue-551 is fixed
     #Then the HTTP status code should be "403"
+
+  @email @skipOnOcV10.11 @skipOnOcV10.12
+  Scenario: A guest user can upload files to a folder shared with them when share_folder is in use
+    Given the administrator has set the default folder for received shares to "Shares"
+    And user "Alice" has been created with default attributes and small skeleton files
+    And the administrator has created guest user "guest1" with email "guest1@example.com"
+    And the HTTP status code should be "201"
+    And user "Alice" has created folder "/tmp"
+    And user "Alice" has shared folder "/tmp" with guest user "guest1@example.com"
+    And guest user "guest1" has registered
+    When user "guest1@example.com" uploads file "textfile.txt" from the guests test data folder to "/tmp/textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" file "/tmp/textfile.txt" should exist

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -19,7 +19,7 @@ Feature: Guests
 
 
   Scenario: cannot create a guest if a user with the same email address exists
-    Given user "existing-user" has been created with default attributes and small skeleton files
+    Given user "existing-user" has been created with default attributes and without skeleton files
     And the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/existing-user" with body
       | key   | email             |
       | value | guest@example.com |
@@ -48,7 +48,7 @@ Feature: Guests
 
   @email @skipOnOcV10.3
   Scenario Outline: guest user can upload files to a folder shared with them
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "<user>" with email "<email-address>"
     And the HTTP status code should be "201"
     And user "Alice" has created folder "/tmp"
@@ -65,7 +65,7 @@ Feature: Guests
 
   @email
   Scenario: guest user can upload chunked files to a folder shared with them
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And the HTTP status code should be "201"
     And user "Alice" has created folder "/tmp"
@@ -81,7 +81,7 @@ Feature: Guests
 
   @email @issue-279
   Scenario: guest user can upload files to a folder shared with them
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And the HTTP status code should be "201"
     And user "Alice" has created folder "/tmp"
@@ -107,7 +107,7 @@ Feature: Guests
   @email
   Scenario: guest user can upload files to a folder shared with them (async upload)
     Given the administrator has enabled async operations
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has created folder "/tmp"
     And user "Alice" has shared folder "/tmp" with user "guest@example.com"
@@ -131,7 +131,7 @@ Feature: Guests
 
   @email
   Scenario: guest user can cancel a chunked upload
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And the HTTP status code should be "201"
     And user "Alice" has created folder "/tmp"
@@ -147,7 +147,7 @@ Feature: Guests
 
   @email
   Scenario: guest user can upload a file and can reshare it
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -164,7 +164,7 @@ Feature: Guests
 
   @email
   Scenario: guest user cannot reshare files
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -187,7 +187,8 @@ Feature: Guests
 
   @email
   Scenario: guest user can log in
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 1" to "/textfile1.txt"
     And the administrator has created guest user "guest" with email "guest@example.com"
     And the HTTP status code should be "201"
     And user "guest" should be a guest user
@@ -218,7 +219,7 @@ Feature: Guests
 
   @email
   Scenario: guest user cannot create new guest users
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has created folder "/tmp"
     And user "Alice" has shared folder "/tmp" with user "guest@example.com"
@@ -481,7 +482,7 @@ Feature: Guests
 
   @email @issue-553
   Scenario: files inside shared folder deleted by guest user are available in sharer trashbin when files_trashbin app is whitelisted
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has created folder "/tmp"
     And user "Alice" has uploaded file with content "some content" to "/tmp/textfile0.txt"
@@ -498,7 +499,7 @@ Feature: Guests
 
   @email @issue-553
   Scenario: guest user can delete shared files when files_trashbin app is whitelisted
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "guest@example.com"
@@ -512,7 +513,7 @@ Feature: Guests
 
   @email @issue-553
   Scenario: guest user cannot delete shared files when files_trashbin app is not whitelisted
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "guest@example.com"

--- a/tests/acceptance/features/apiGuests/guests.feature
+++ b/tests/acceptance/features/apiGuests/guests.feature
@@ -6,7 +6,7 @@ Feature: Guests
     And using new dav path
 
   @skipOnOcV10.3
-  Scenario Outline: Creating a guest user works fine
+  Scenario Outline: creating a guest user works fine
     When the administrator creates guest user "<user>" with email "<email-address>" using the API
     Then the HTTP status code should be "201"
     And user "<user>" should be a guest user
@@ -18,7 +18,7 @@ Feature: Guests
       | betty_anne+bob-burns@email.com | betty_anne+bob-burns |
 
 
-  Scenario: Cannot create a guest if a user with the same email address exists
+  Scenario: cannot create a guest if a user with the same email address exists
     Given user "existing-user" has been created with default attributes and small skeleton files
     And the administrator sends HTTP method "PUT" to OCS API endpoint "/cloud/users/existing-user" with body
       | key   | email             |
@@ -28,7 +28,7 @@ Feature: Guests
     And user "guest" should not exist
 
 
-  Scenario: A guest user cannot upload files to their own storage
+  Scenario: guest user cannot upload files to their own storage
     Given the administrator has created guest user "guest" with email "guest@example.com"
     And the HTTP status code should be "201"
     When user "guest@example.com" uploads overwriting file "textfile.txt" from the guests test data folder to "/myfile.txt" with all mechanisms using the WebDAV API
@@ -38,7 +38,7 @@ Feature: Guests
     And as "Alice" file "/textfile.txt" should not exist
 
 
-  Scenario: A guest user cannot upload files to their own storage (async upload)
+  Scenario: guest user cannot upload files to their own storage (async upload)
     Given the administrator has enabled async operations
     And the administrator has created guest user "guest" with email "guest@example.com"
     When user "guest@example.com" uploads file "textfile.txt" from the guests test data folder asynchronously to "/textfile.txt" in 3 chunks using the WebDAV API
@@ -47,7 +47,7 @@ Feature: Guests
     And as "Alice" file "/textfile.txt" should not exist
 
   @email @skipOnOcV10.3
-  Scenario Outline: A guest user can upload files to a folder shared with them
+  Scenario Outline: guest user can upload files to a folder shared with them
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "<user>" with email "<email-address>"
     And the HTTP status code should be "201"
@@ -64,7 +64,7 @@ Feature: Guests
       | betty_anne+bob-burns@email.com | betty_anne+bob-burns |
 
   @email
-  Scenario: A guest user can upload chunked files to a folder shared with them
+  Scenario: guest user can upload chunked files to a folder shared with them
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And the HTTP status code should be "201"
@@ -80,7 +80,7 @@ Feature: Guests
     And as "Alice" file "/tmp/myChunkedFile.txt" should exist
 
   @email @issue-279
-  Scenario: A guest user can upload files to a folder shared with them
+  Scenario: guest user can upload files to a folder shared with them
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And the HTTP status code should be "201"
@@ -105,7 +105,7 @@ Feature: Guests
     """
 
   @email
-  Scenario: A guest user can upload files to a folder shared with them (async upload)
+  Scenario: guest user can upload files to a folder shared with them (async upload)
     Given the administrator has enabled async operations
     And user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -130,7 +130,7 @@ Feature: Guests
     """
 
   @email
-  Scenario: A guest user can cancel a chunked upload
+  Scenario: guest user can cancel a chunked upload
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And the HTTP status code should be "201"
@@ -146,7 +146,7 @@ Feature: Guests
     And as "Alice" file "/tmp/myChunkedFile.txt" should not exist
 
   @email
-  Scenario: A guest user can upload a file and can reshare it
+  Scenario: guest user can upload a file and can reshare it
     Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
@@ -163,7 +163,7 @@ Feature: Guests
     And the HTTP status code should be "200"
 
   @email
-  Scenario: A guest user cannot reshare files
+  Scenario: guest user cannot reshare files
     Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
@@ -186,7 +186,7 @@ Feature: Guests
     And the HTTP status code should be "200"
 
   @email
-  Scenario: A created guest user can log in
+  Scenario: guest user can log in
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And the HTTP status code should be "201"
@@ -198,7 +198,7 @@ Feature: Guests
       | /textfile1.txt |
 
 
-  Scenario: Trying to create a guest user that already exists
+  Scenario: guest user cannot be created if it already exists
     Given the administrator has created guest user "guest" with email "guest@example.com"
     And the HTTP status code should be "201"
     And user "guest" should be a guest user
@@ -206,7 +206,7 @@ Feature: Guests
     Then the HTTP status code should be "422"
 
 
-  Scenario: removing a guest user from a group
+  Scenario: guest user can be removed from a group
     Given the administrator has created guest user "guest" with email "guest@example.com"
     And the HTTP status code should be "201"
     And group "guests_app" has been created
@@ -217,7 +217,7 @@ Feature: Guests
     And user "guest@example.com" should not belong to group "guests_app"
 
   @email
-  Scenario: A guest user can not create new guest users
+  Scenario: guest user cannot create new guest users
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has created folder "/tmp"
@@ -227,7 +227,7 @@ Feature: Guests
     Then the HTTP status code should be "403"
 
   @email
-  Scenario: Create a regular user using the same email address as an existing guest user
+  Scenario: create a regular user using the same email address as an existing guest user
     Given the administrator has created guest user "guest" with email "guest@example.com"
     When the administrator creates these users with skeleton files:
       | username    | email             |
@@ -235,7 +235,7 @@ Feature: Guests
     Then the email address of user "regularUser" should be "guest@example.com"
 
   @email @skip_on_objectstore
-  Scenario: A guest user cannot view versions of resource when files_versions app is not in whitelist
+  Scenario: guest user cannot view versions of resources when files_versions app is not in whitelist
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And user "Alice" has uploaded file with content "some added content" to "textfile0.txt"
@@ -250,7 +250,7 @@ Feature: Guests
     But the version folder of file "/textfile0.txt" for user "Alice" should contain "1" element
 
   @email @skip_on_objectstore
-  Scenario: A guest user cannot add versions of resource when files_versions app is not in whitelist
+  Scenario: guest user cannot add versions of resources when files_versions app is not in whitelist
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -264,7 +264,7 @@ Feature: Guests
     And the version folder of file "/textfile0.txt" for user "Alice" should contain "0" element
 
   @email
-  Scenario: A guest user can view versions of resource when files_versions app is in whitelist
+  Scenario: guest user can view versions of resources when files_versions app is in whitelist
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And user "Alice" has uploaded file with content "some added content" to "textfile0.txt"
@@ -281,7 +281,7 @@ Feature: Guests
     And the content of file "/textfile0.txt" for user "Alice" should be "some added content"
 
   @email
-  Scenario: A guest user can add versions of resource when files_versions app is in whitelist
+  Scenario: guest user can add versions of resources when files_versions app is in whitelist
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -297,7 +297,7 @@ Feature: Guests
     And the content of file "/textfile0.txt" for user "Alice" should be "some new content"
 
   @email
-  Scenario: A guest user can add comments on a resource when comments app is in whitelist
+  Scenario: guest user can add comments on a resource when comments app is in whitelist
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -312,7 +312,7 @@ Feature: Guests
       | guest@example.com | A comment from guest |
 
   @email
-  Scenario: A guest user can view comments on a resource when comments app is in whitelist
+  Scenario: guest user can view comments on a resource when comments app is in whitelist
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And user "Alice" has commented with content "My first comment" on folder "/textfile0.txt"
@@ -331,7 +331,7 @@ Feature: Guests
       | Alice | My first comment |
 
   @email
-  Scenario: A guest user can edit own comments on a shared resource when comments app is in whitelist
+  Scenario: guest user can edit own comments on a shared resource when comments app is in whitelist
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -347,7 +347,7 @@ Feature: Guests
       | guest@example.com | My edited comment |
 
   @email
-  Scenario: A guest user can delete own comments on a shared resource when comments app is in whitelist
+  Scenario: guest user can delete own comments on a shared resource when comments app is in whitelist
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And user "Alice" has commented with content "My first comment" on folder "/textfile0.txt"
@@ -365,7 +365,7 @@ Feature: Guests
       | Alice | My first comment |
 
   @email
-  Scenario: A guest user can view tags on resource when systemtags app is in whitelist
+  Scenario: guest user can view tags on resources when systemtags app is in whitelist
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created a "normal" tag with name "MyFirstTag"
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
@@ -382,7 +382,7 @@ Feature: Guests
       | MyFirstTag | normal |
 
   @email
-  Scenario: A guest user can add tags on resource when systemtags app is in whitelist
+  Scenario: guest user can add tags on resources when systemtags app is in whitelist
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created a "normal" tag with name "MyFirstTag"
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
@@ -398,7 +398,7 @@ Feature: Guests
       | MyFirstTag | normal |
 
   @email
-  Scenario: A guest user can delete tags on resource when systemtags app is in whitelist
+  Scenario: guest user can delete tags on resources when systemtags app is in whitelist
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"
@@ -417,7 +417,7 @@ Feature: Guests
       | MySecondTag | normal |
 
   @email
-  Scenario: a guest user cannot delete other users comments on resource when the comments app is whitelisted
+  Scenario: guest user cannot delete other users comments on resources when the comments app is whitelisted
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And user "Alice" has commented with content "My first comment" on file "/textfile0.txt"
@@ -433,7 +433,7 @@ Feature: Guests
       | Alice | My first comment |
 
   @email @issue-549
-  Scenario: a guest user cannot add comments on resource when the comments app is not whitelisted
+  Scenario: guest user cannot add comments on resources when the comments app is not whitelisted
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -447,7 +447,7 @@ Feature: Guests
     #Then the HTTP status code should be "403"
 
   @email @issue-549
-  Scenario: a guest user cannot view comments on a resource when the comments app is not whitelisted
+  Scenario: guest user cannot view comments on a resources when the comments app is not whitelisted
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And user "Alice" has commented with content "My first comment" on file "/textfile0.txt"
@@ -465,7 +465,7 @@ Feature: Guests
     #And the single response should contain a property "oc:comments-count" with value "0"
 
   @email @issue-549
-  Scenario: a guest user cannot delete their comments on a resource when the comments app is not whitelisted
+  Scenario: guest user cannot delete their comments on a resource when the comments app is not whitelisted
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
     And the administrator has created guest user "guest" with email "guest@example.com"
@@ -480,7 +480,7 @@ Feature: Guests
     #Then the HTTP status code should be "403"
 
   @email @issue-553
-  Scenario: files inside shared folder deleted by guest user is available in sharer trashbin when files_trashbin app is whitelisted
+  Scenario: files inside shared folder deleted by guest user are available in sharer trashbin when files_trashbin app is whitelisted
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has created folder "/tmp"
@@ -497,7 +497,7 @@ Feature: Guests
     And as "Alice" the file with original path "/tmp/textfile0.txt" should exist in the trashbin
 
   @email @issue-553
-  Scenario: a guest user can delete shared files when files_trashbin app is whitelisted
+  Scenario: guest user can delete shared files when files_trashbin app is whitelisted
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
@@ -511,7 +511,7 @@ Feature: Guests
     And as "guest@example.com" file "/textfile0.txt" should not exist
 
   @email @issue-553
-  Scenario: a guest user cannot delete shared files when files_trashbin app is not whitelisted
+  Scenario: guest user cannot delete shared files when files_trashbin app is not whitelisted
     Given user "Alice" has been created with default attributes and small skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
@@ -525,7 +525,7 @@ Feature: Guests
     And as "guest@example.com" file "/textfile0.txt" should not exist
 
   @email @issue-551
-  Scenario: a guest user cannot add tags on resource when systemtags app is not whitelisted
+  Scenario: guest user cannot add tags on resources when systemtags app is not whitelisted
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created a "normal" tag with name "MyFirstTag"
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
@@ -540,7 +540,7 @@ Feature: Guests
     #Then the HTTP status code should be "403"
 
   @email @issue-551
-  Scenario: a guest user cannot view tags of resource when systemtags app is not whitelisted
+  Scenario: guest user cannot view tags of resources when systemtags app is not whitelisted
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created a "normal" tag with name "MyFirstTag"
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"
@@ -556,7 +556,7 @@ Feature: Guests
     #Then the HTTP status code should be "403"
 
   @email @issue-551
-  Scenario: a guest user cannot remove tags of resource when systemtags app is not whitelisted
+  Scenario: guest user cannot remove tags of resources when systemtags app is not whitelisted
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created a "normal" tag with name "MyFirstTag"
     And user "Alice" has uploaded file with content "some content" to "textfile0.txt"

--- a/tests/acceptance/features/webUIGuests/guests.feature
+++ b/tests/acceptance/features/webUIGuests/guests.feature
@@ -6,7 +6,7 @@ Feature: Guests
     And using new dav path
 
   @email
-  Scenario: Guest user sets its own password
+  Scenario: guest user sets their own password
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has created folder "/tmp"
@@ -17,7 +17,7 @@ Feature: Guests
     And folder "tmp" should be listed on the webUI
 
   @email
-  Scenario: Guest user uses the link twice
+  Scenario: guest user uses the registration link twice
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has created folder "/tmp"
@@ -28,7 +28,7 @@ Feature: Guests
     And a warning should be displayed on the set-password-page saying "The token is invalid"
 
   @email @skipOnOcV10.2 @skipOnOcV10.3
-  Scenario Outline: User uses valid email to create a guest user
+  Scenario Outline: ordinary user uses valid email to create a guest user
     Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     When the user shares file "data.zip" with guest user with email "<email-address>" using the webUI
@@ -40,7 +40,7 @@ Feature: Guests
       | Betty_Anne+Bob-Burns@email.com |
 
   @email
-  Scenario: User uses some random string email to create a guest user
+  Scenario: ordinary user uses some random string email to create a guest user
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has logged in using the webUI
     And the user has opened the share dialog for file "textfile0.txt"
@@ -50,7 +50,7 @@ Feature: Guests
     And user "somestring" should not exist
 
   @email @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
-  Scenario Outline: User cannot use an email of a blocked domain to create a guest user
+  Scenario Outline: ordinary user cannot use an email of a blocked domain to create a guest user
     Given the administrator has added config key "blockdomains" with value "<block-domains>" in app "guests"
     And user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has logged in using the webUI
@@ -65,7 +65,7 @@ Feature: Guests
       | test.com,gmail.com,somewhere.org |
 
   @mailhog @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
-  Scenario: User can use an email of a not-blocked domain to create a guest user even if blocked domain is substring of email domain
+  Scenario: ordinary user can use an email of a not-blocked domain to create a guest user even if blocked domain is substring of email domain
     Given the administrator has added config key "blockdomains" with value "test.com,gmail.com" in app "guests"
     And user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has logged in using the webUI
@@ -73,7 +73,7 @@ Feature: Guests
     Then user "valid@notgmail.com" should exist
 
   @email @skipOnOcV10.2
-  Scenario: User uses invalid email to create a guest user
+  Scenario: ordinary user uses invalid email to create a guest user
     Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     When the user shares file "testimage.jpg" with guest user with email "invalid@email.com()9876a" using the webUI
@@ -83,7 +83,7 @@ Feature: Guests
     And user "invalid@email.com()9876a" should not exist
 
   @email @skipOnOcV10.2
-  Scenario: User tries to create a guest user via email with an already used email
+  Scenario: ordinary user tries to create a guest user via email with an already used email
     Given these users have been created with large skeleton files:
       | username | email        |
       | Alice    | Alice@oc.com |
@@ -95,7 +95,7 @@ Feature: Guests
     And user "Brian@oc.com" should not be displayed in the dropdown as a guest user
 
   @email @issue-329 @skipOnOcV10.2
-  Scenario: User tries to create a guest user when a server email mode is not set
+  Scenario: ordinary user tries to create a guest user when a server email mode is not set
     Given user "Brian" has been created with default attributes and large skeleton files
     And user "Brian" has logged in using the webUI
     When the administrator deletes system config key "mail_smtpmode" using the occ command
@@ -107,7 +107,7 @@ Feature: Guests
     # And user "valid@email.com" should not exist
 
   @email @skipOnOcV10.2 @skipOnFIREFOX
-  Scenario: Administrator changes the guest user's password in users menu
+  Scenario: administrator changes the guest user's password in users menu
     Given user "admin" has uploaded file with content "new content" to "new-file.txt"
     And the administrator has logged in using the webUI
     And the user shares file "new-file.txt" with guest user with email "valid@email.com" using the webUI
@@ -120,7 +120,7 @@ Feature: Guests
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   @email @issue-329 @skipOnOcV10.2
-  Scenario: User tries to create a guest user when a server email is invalid
+  Scenario: ordinary user tries to create a guest user when a server email is invalid
     Given user "Brian" has been created with default attributes and large skeleton files
     And user "Brian" has logged in using the webUI
     When the administrator adds system config key "mail_smtphost" with value "conkey" using the occ command
@@ -132,7 +132,7 @@ Feature: Guests
     # And user "valid@email.com" should not exist
 
   @email @skipOnOcV10.2
-  Scenario: Administrator deletes a guest user in user's menu
+  Scenario: administrator deletes a guest user in user's menu
     Given user "admin" has uploaded file with content "new content" to "new-file.txt"
     And the administrator has logged in using the webUI
     And the user shares file "new-file.txt" with guest user with email "valid@email.com" using the webUI
@@ -141,7 +141,7 @@ Feature: Guests
     Then user "valid@email.com" should not exist
 
   @email @skipOnOcV10.2
-  Scenario Outline: User creates a guest user with email that contains capital letters
+  Scenario Outline: ordinary user creates a guest user with email that contains capital letters
     Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     When the user shares file "data.zip" with guest user with email "<share-email>" using the webUI
@@ -159,7 +159,7 @@ Feature: Guests
       | user@example.com | USER@example.com | user@EXAMPLE.com |
 
   @email
-  Scenario: Guest user is not able to upload or create files
+  Scenario: guest user is not able to upload or create files
     Given user "Alice" has been created with default attributes and large skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has shared file "lorem.txt" with user "guest@example.com"
@@ -168,7 +168,7 @@ Feature: Guests
     Then the user should not have permission to upload or create files
 
   @email @skipOnOcV10.3
-  Scenario Outline: Guest user is able to upload or create files inside the received share(with change permission)
+  Scenario Outline: guest user is able to upload or create files inside a received share with change permission
     Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     When the user shares folder "simple-folder" with guest user with email "<email-address>" using the webUI
@@ -186,7 +186,7 @@ Feature: Guests
       | Betty_Anne+Bob-Burns@email.com |
 
   @email
-  Scenario: Guest user tries to upload or create files inside the received share(read only permission)
+  Scenario: guest user tries to upload or create files inside a received share with read only permission
     Given user "Alice" has been created with default attributes and large skeleton files
     And the administrator has created guest user "guest" with email "guest@example.com"
     And user "Alice" has shared folder "simple-folder" with user "guest@example.com"
@@ -198,7 +198,7 @@ Feature: Guests
     Then the user should not have permission to upload or create files
 
   @email
-  Scenario: Create a regular user using the same email address of an existing guest user
+  Scenario: create a regular user using the same email address as an existing guest user
     Given the administrator has created guest user "guest" with email "guest@example.com"
     And the administrator has logged in using the webUI
     And the administrator has browsed to the users page


### PR DESCRIPTION
## Description
When the core system setting `share_folder` is used, guest users have a problem - see the issue link below.

The problem was fixed in core - see the PR link below.

This guests PR adds test coverage. A scenario is added that sets `share_folder` and then verifies that a guest user can use a folder that is shared with them.

The scenario fails when run with core code before https://github.com/owncloud/core/pull/40864
```
Feature: Guests

  Background:                       # /home/phil/git/owncloud/core/apps-external/guests/tests/acceptance/features/apiGuests/guests.feature:4
    Given using OCS API version "1" # FeatureContext::usingOcsApiVersion()
    And using new dav path          # FeatureContext::usingOldOrNewDavPath()

  @email @skipOnOcV10.11 @skipOnOcV10.12
  Scenario: A guest user can upload files to a folder shared with them when shared_folder is in use                                         # /home/phil/git/owncloud/core/apps-external/guests/tests/acceptance/features/apiGuests/guests.feature:575
    Given the administrator has set the default folder for received shares to "Shares"                                                      # OccContext::theAdministratorHasSetTheDefaultFolderForReceivedSharesTo()
    And user "Alice" has been created with default attributes and small skeleton files                                                      # FeatureContext::userHasBeenCreatedWithDefaultAttributes()
    And the administrator has created guest user "guest1" with email "guest1@example.com"                                                   # GuestsContext::theAdministratorHasCreatedAGuestUser()
    And the HTTP status code should be "201"                                                                                                # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    And user "Alice" has created folder "/tmp"                                                                                              # FeatureContext::userHasCreatedFolder()
    And user "Alice" has shared folder "/tmp" with guest user "guest1@example.com"                                                          # GuestsContext::userHasSharedFolderWithGuestUser()
    And guest user "guest1" has registered                                                                                                  # GuestsContext::guestUserHasRegistered()
    When user "guest1@example.com" uploads file "textfile.txt" from the guests test data folder to "/tmp/textfile.txt" using the WebDAV API # GuestsContext::userUploadsFileFromGuestsDataFolderTo()
    Then the HTTP status code should be "201"                                                                                               # FeatureContext::thenTheHTTPStatusCodeShouldBe()
      HTTP status code 409 is not the expected value 201
      Failed asserting that 409 matches expected '201'.
    And as "Alice" file "/tmp/textfile.txt" should exist                                                                                    # FeatureContext::asFileOrFolderShouldExist()

--- Failed scenarios:

    /home/phil/git/owncloud/core/apps-external/guests/tests/acceptance/features/apiGuests/guests.feature:575

1 scenario (1 failed)
12 steps (10 passed, 1 failed, 1 skipped)
0m25.98s (18.76Mb)
runsh: Total 1 scenarios (0 passed, 1 failed)
runsh: Exit code of main run: 1
runsh: Total unexpected failed scenarios throughout the test run:
apiGuests/guests.feature:575
```

When I use core from the PR, it passes.

## Related Issue
https://github.com/owncloud/enterprise/issues/5842

and core PR https://github.com/owncloud/core/pull/40864

## How Has This Been Tested?
CI and locally


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

