### PR TITLE
fix: add `impersonate` to default whitelist

### DIFF
--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -31,7 +31,7 @@ use OCP\Template;
  */
 class AppWhitelist {
 	public const CORE_WHITELIST = ',core,files,dav,federatedfilesharing,guests,encryption,files_primary_s3,files_antivirus,files_external,files_external_dropbox,files_external_ftp,files_ldap_home,files_onedrive,sharepoint,files_external_s3,windows_network_drive,admin_audit,firewall,ransomware_protection';
-	public const DEFAULT_WHITELIST = 'settings,avatar,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications,password_policy,oauth2,files_pdfviewer,files_mediaviewer,richdocuments,onlyoffice,wopi,oco_selfservice,twofactor_totp';
+	public const DEFAULT_WHITELIST = 'settings,avatar,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications,password_policy,oauth2,files_pdfviewer,files_mediaviewer,richdocuments,onlyoffice,wopi,oco_selfservice,twofactor_totp,impersonate';
 
 	public static function preSetup($params) {
 		$uid = $params['user'];


### PR DESCRIPTION
## Description
Add `impersonate` to default whitelist.

## Motivation and Context
Currently, it is possible for an admin to impersonate guest users however logging out will destroy admin's session. Since admin can already impersonate guests, this should be consistent with the behaviour of "normal" users where admin's session persists.

## How Has This Been Tested?
Manually. Add `impersonate` to guests app whitelist and be sure admin's session is still active after logging out.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

