### PR TITLE
Fix: respect the usewhitelist flag

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -103,6 +103,11 @@ class Application extends App {
 			return;
 		}
 		$appWhiteList = AppWhitelist::getWhitelist();
+ 
+		// If the usewhitelist flag is set to false, then we do not set the whitelistedAppsForGuests attribute in the event
+		if ($server->getConfig()->getAppValue(self::APP_NAME, 'usewhitelist', 'true') === 'false') {
+			return;
+		}
 
 		/**
 		 * Add whitelistedAppsForGuests attribute only if it is not present. There is a


### PR DESCRIPTION
## Description
Respect the `usewhitelist` flag

## Related Issue
https://github.com/owncloud/enterprise/issues/6312

## Motivation and Context
We do not want to send any information to core about the whitelisted apps in case the `usewhitelist` flag is set to `false`, which means admin opted out the `Limit guest access to an app whitelist` checkbox

## How Has This Been Tested?
- oC 10.13.4 + twofactor_totp 0.8.1
- remove the guests app version which comes bundled in 10.13.4 and install 0.9.3 (we install this version as this was the last version where `twofactor_totp` was not yet included in the default whitelist, see https://github.com/owncloud/guests/pull/479, introduced in 0.10.0)
- as admin opt-out the `Limit guest access to an app whitelist` checkbox
- login as guest, TOTP section is presented in the settings/personal?sectionid=security section --> all good
- now update the guests app to latest version 0.12.3
- login as guest: without this fix, TOTP section is no longer available. With this fix, TOTP section is still available
- also tested when globally enforcing 2FA

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.