### PR TITLE
fix: respect default_language for guests invitation

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -67,6 +67,7 @@ class Application extends App {
 					$server->getMailer(),
 					new \OCP\Defaults(),
 					$server->getL10N(self::APP_NAME),
+					$server->getConfig(),
 					$server->getUserManager(),
 					$server->getURLGenerator()
 				);

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -116,12 +116,8 @@ class Mail {
 			['fileId' => $share->getNode()->getId()]
 		);
 
-		$usedeflanguage = null;
-		$defaultLang = \OC::$server->getConfig()->getSystemValue('default_language', false);
-		// if set, use default_language in config.php for the guests template
-		if ($defaultLang !== false) {
-			$usedeflanguage = \OC::$server->getL10N('lib', $defaultLang);
-			$subject = (string)$usedeflanguage->t('%s shared »%s« with you', [$senderDisplayName, $filename]);
+		if ($this->checkDefaultLanguage() !== null) {
+			$subject = (string)$this->checkDefaultLanguage()->t('%s shared »%s« with you', [$senderDisplayName, $filename]);
 		}
 
 		list($htmlBody, $textBody) = $this->createMailBody(
@@ -132,7 +128,7 @@ class Mail {
 			$senderDisplayName,
 			$expiration,
 			$shareWithEmail,
-			$usedeflanguage
+			$this->checkDefaultLanguage()
 		);
 
 		try {
@@ -176,12 +172,8 @@ class Mail {
 
 		$subject = (string)$this->l10n->t('%s invited you', [$senderDisplayName]);
 
-		$usedeflanguage = null;
-		$defaultLang = \OC::$server->getConfig()->getSystemValue('default_language', false);
-		// if set, use default_language in config.php for the guests template
-		if ($defaultLang !== false) {
-			$usedeflanguage = \OC::$server->getL10N('lib', $defaultLang);
-			$subject = (string)$usedeflanguage->t('%s invited you', [$senderDisplayName]);
+		if ($this->checkDefaultLanguage() !== null) {
+			$subject = (string)$this->checkDefaultLanguage()->t('%s invited you', [$senderDisplayName]);
 		}
 
 		list($htmlBody, $textBody) = $this->createMailBody(
@@ -192,7 +184,7 @@ class Mail {
 			$senderDisplayName,
 			null,
 			$shareWithEmail,
-			$usedeflanguage
+			$this->checkDefaultLanguage()
 		);
 
 		try {
@@ -256,5 +248,18 @@ class Mail {
 		$plainTextMail = $plainText->fetchPage();
 
 		return [$htmlMail, $plainTextMail];
+	}
+
+	/**
+	 * check if default_language is defined in config.php
+	 * @return string|null
+	*/
+	private function checkDefaultLanguage() {
+		$useDefaultLanguage = null;
+		$defaultLang = \OC::$server->getConfig()->getSystemValue('default_language', false);
+		if ($defaultLang !== false) {
+			$useDefaultLanguage = \OC::$server->getL10N('lib', $defaultLang);
+		}
+		return $useDefaultLanguage;
 	}
 }

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -253,8 +253,8 @@ class Mail {
 	}
 
 	/**
-		 * get default_language is defined in config.php
-		*/
+	 * get default_language is defined in config.php
+	 */
 	private function getDefaultLanguage() {
 		$useDefaultLanguage = null;
 		$defaultLang = $this->config->getSystemValue('default_language', false);

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -116,6 +116,7 @@ class Mail {
 			['fileId' => $share->getNode()->getId()]
 		);
 
+		$usedeflanguage = null;
 		$defaultLang = \OC::$server->getConfig()->getSystemValue('default_language', false);
 		// if set, use default_language in config.php for the guests template
 		if ($defaultLang !== false) {
@@ -175,6 +176,7 @@ class Mail {
 
 		$subject = (string)$this->l10n->t('%s invited you', [$senderDisplayName]);
 
+		$usedeflanguage = null;
 		$defaultLang = \OC::$server->getConfig()->getSystemValue('default_language', false);
 		// if set, use default_language in config.php for the guests template
 		if ($defaultLang !== false) {

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -107,8 +107,8 @@ class Mail {
 		$this->logger->debug("sending invite to $shareWith: $registerLink", ['app' => 'guests']);
 
 		$filename = \trim($share->getTarget(), '/');
-		$useDefaultLanguage = $this->getDefaultLanguage();
-		$l10n = $useDefaultLanguage ?? $this->l10n;
+		$defaultLanguage = $this->getDefaultLanguage();
+		$l10n = $defaultLanguage ?? $this->l10n;
 		$subject = (string)$l10n->t('%s shared »%s« with you', [$senderDisplayName, $filename]);
 		$expiration = $share->getExpirationDate();
 		if ($expiration instanceof \DateTime) {
@@ -132,7 +132,7 @@ class Mail {
 			$senderDisplayName,
 			$expiration,
 			$shareWithEmail,
-			$useDefaultLanguage
+			$defaultLanguage
 		);
 
 		try {
@@ -174,8 +174,8 @@ class Mail {
 
 		$this->logger->debug("sending invite to $shareWith: $registerLink", ['app' => 'guests']);
 
-		$useDefaultLanguage = $this->getDefaultLanguage();
-		$l10n = $useDefaultLanguage ?? $this->l10n;
+		$defaultLanguage = $this->getDefaultLanguage();
+		$l10n = $defaultLanguage ?? $this->l10n;
 		$subject = (string)$l10n->t('%s invited you', [$senderDisplayName]);
 
 		list($htmlBody, $textBody) = $this->createMailBody(
@@ -186,7 +186,7 @@ class Mail {
 			$senderDisplayName,
 			null,
 			$shareWithEmail,
-			$useDefaultLanguage
+			$defaultLanguage
 		);
 
 		try {
@@ -223,6 +223,7 @@ class Mail {
 	 * @param ?string $link link to the shared file
 	 * @param ?int $expiration expiration date (timestamp)
 	 * @param string $guestEmail
+	 * @param IL10N|null $overrideL10n language to be used
 	 * @return array an array of the html mail body and the plain text mail body
 	 */
 	private function createMailBody($filename, $link, $passwordLink, $cloudName, $displayName, $expiration, $guestEmail, $overrideL10n = null) {
@@ -254,13 +255,14 @@ class Mail {
 
 	/**
 	 * get default_language if defined in config.php
+	 * @return IL10N|null
 	 */
 	private function getDefaultLanguage() {
-		$useDefaultLanguage = null;
+		$defaultLanguage = null;
 		$defaultLang = $this->config->getSystemValue('default_language', false);
 		if ($defaultLang !== false) {
-			$useDefaultLanguage = \OC::$server->getL10N('lib', $defaultLang);
+			$defaultLanguage = \OC::$server->getL10N('lib', $defaultLang);
 		}
-		return $useDefaultLanguage;
+		return $defaultLanguage;
 	}
 }

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -253,7 +253,7 @@ class Mail {
 	}
 
 	/**
-	 * get default_language is defined in config.php
+	 * get default_language if defined in config.php
 	 */
 	private function getDefaultLanguage() {
 		$useDefaultLanguage = null;

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -252,7 +252,7 @@ class Mail {
 
 	/**
 	 * check if default_language is defined in config.php
-	 * @return string|null
+	 * @return OCP\IL10N|null
 	*/
 	private function checkDefaultLanguage() {
 		$useDefaultLanguage = null;


### PR DESCRIPTION
## Description
Respect default_language for guests invitation

## Related issue
https://github.com/owncloud/enterprise/issues/6322

## Motivation and Context
Currently, the `default_language` config.php option is wrongly not considered when generating templates for guests invitation. This has the consequence that the language of the user creating the guest is rather used, which may not be the same as the one used by the guest (especially true in case of guest users).

Note: the `sendGuestPlainInviteMail` method needed also to be adjusted as this is what is being used when creating a guest directly from custom groups --> https://github.com/owncloud/customgroups/blob/master/lib/Service/GuestIntegrationHelper.php#L124

## How Has This Been Tested?
Set `default_language` in config.php and observe this language is now used for guests templates.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.