### PR TITLE
fix: detect files app in guest whitelist checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- [#618](https://github.com/owncloud/guests/pull/618) - fix: detect files app in guest whitelist checking
 
 ## [0.12.4] - 2024-01-23
 

--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -49,7 +49,7 @@ class AppWhitelist {
 			$app = self::getRequestedApp($path);
 			$whitelist = self::getWhitelist();
 
-			if (!\in_array($app, $whitelist)) {
+			if (!\in_array($app, $whitelist, true)) {
 				\header('HTTP/1.0 403 Forbidden');
 				$l = \OC::$server->getL10NFactory()->get('guests');
 				Template::printErrorPage($l->t(
@@ -90,6 +90,8 @@ class AppWhitelist {
 			return 'heartbeat';
 		} elseif (\substr($url, 0, 13) === '/dav/comments') {
 			return 'comments';
+		} elseif (\substr($url, 0, 11) === '/dav/files/') {
+			return 'files';
 		}
 		return false;
 	}


### PR DESCRIPTION
## Description
In `AppWhitelist.php` function preSetup:
```
			$path = \OC::$server->getRequest()->getPathInfo();
```
Path can be something like `/dav/files/guest@example.com/`

In that case, `getRequestedApp($path)` was returning `false`

Actually a path like that is to do with the files app. So return 'files'.

Then we can do `if (!\in_array($app, $whitelist, true))` (use a strict check that the app has to be in the whitelist array). This will help ensure that only requests to "app URLs" that are whitelisted will work for guests.

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

