### PR TITLE
chore(ci): move basic webUI acceptance tests to GitHub workflows

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -59,32 +59,6 @@ config = {
     "phan": False,
     "phpunit": False,
     "acceptance": {
-        "webUI": {
-            "suites": {
-                "webUIGuests": "webUIGuest",
-            },
-            "browsers": [
-                "chrome",
-                "firefox",
-            ],
-            "databases": [
-                "mysql:8.0",
-                "postgres:9.4",
-                "oracle",
-            ],
-            "emailNeeded": True,
-        },
-        "api": {
-            "suites": [
-                "apiGuests",
-            ],
-            "databases": [
-                "mysql:8.0",
-                "postgres:9.4",
-                "oracle",
-            ],
-            "emailNeeded": True,
-        },
         "api-scality": {
             "suites": {
                 "apiGuests": "apiGuestsScality",

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,3 +63,21 @@ jobs:
     with:
       app-name: ${{ needs.get-vars.outputs.app-name }}
       php-version: '8.3'
+
+  acceptance-api:
+    name: API acceptance tests
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/acceptance.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      do-api-tests: true
+
+  acceptance-webui:
+    name: WebUI acceptance tests
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/acceptance.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      do-webui-tests: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,3 +63,23 @@ jobs:
     with:
       app-name: ${{ needs.get-vars.outputs.app-name }}
       php-version: '8.3'
+
+  acceptance-api:
+    name: API acceptance tests
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/acceptance.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      do-api-tests: true
+      use-email-server: true
+
+  acceptance-webui:
+    name: WebUI acceptance tests
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/acceptance.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      do-webui-tests: true
+      use-email-server: true

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,11 @@ $(nodejs_deps): package.json yarn.lock
 
 $(KARMA): $(nodejs_deps)
 
+# Installs dependencies and does any build actions needed for the app to run in CI
+.PHONY: ci
+ci: vendor
+	@echo dependencies and build actions for CI are completed
+
 ##------------
 ## Tests
 ##------------


### PR DESCRIPTION
Note: there are other drone pipelines that run acceptance tests with scalityS3 and cephS3 storage in place.

Those need more setup to be able to run in a workflow, that will be done later.
