### PR TITLE
fix: remove leading comma from CORE_WHITELIST constant

### DIFF
--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -30,7 +30,7 @@ use OCP\Template;
  * @package OCA\Guests
  */
 class AppWhitelist {
-	public const CORE_WHITELIST = ',core,files,dav,federatedfilesharing,guests,encryption,files_primary_s3,files_antivirus,files_external,files_external_dropbox,files_external_ftp,files_ldap_home,files_onedrive,sharepoint,files_external_s3,windows_network_drive,admin_audit,firewall,ransomware_protection';
+	public const CORE_WHITELIST = 'core,files,dav,federatedfilesharing,guests,encryption,files_primary_s3,files_antivirus,files_external,files_external_dropbox,files_external_ftp,files_ldap_home,files_onedrive,sharepoint,files_external_s3,windows_network_drive,admin_audit,firewall,ransomware_protection';
 	public const DEFAULT_WHITELIST = 'settings,avatar,files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications,password_policy,oauth2,files_pdfviewer,files_mediaviewer,richdocuments,onlyoffice,wopi,oco_selfservice,twofactor_totp,impersonate';
 
 	public static function preSetup($params) {


### PR DESCRIPTION
This avoids having an accidental empty string in the array returned by getWhitelist().

Suggested in issue #696 